### PR TITLE
feat(api): Allow oauth authentification for rdvinsertion endpoints

### DIFF
--- a/.env.rdv_solidarites.sample
+++ b/.env.rdv_solidarites.sample
@@ -16,6 +16,8 @@ RDV_INSERTION_HOST=http://localhost:8000
 # It is needed as an env variable because seeds can be used on staging envs
 RDV_INSERTION_SECRET=rdv-solidarites
 
+RDV_INSERTION_OAUTH_APPLICATION_UID="zC24y16rYftyrBgTj8h08g1NZKkwStXWe3E_lLMGoHc"
+
 
 DEFAULT_DOMAIN_IS_RDV_SOLIDARITES=true
 

--- a/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
+++ b/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
@@ -3,15 +3,21 @@ class Api::Rdvinsertion::AgentAuthBaseController < Api::V1::AgentAuthBaseControl
 
   # L'authentification par secret partagé est faite via un secret partagé avec rdv-insertion qui se trouve
   # dans la variable d'environnement `SHARED_SECRET_FOR_AGENTS_AUTH`. Elle a vocation à disparaître.
-  # L'authentification par OAuth sera la seule méthode d'authentification valide.
+  # L'authentification par OAuth sera la seule méthode d'authentification valide. Elle n'est autorisée que
+  # pour l'application rdv-insertion, dont l'uid est stocké dans la variable d'environnement
+  # `RDV_INSERTION_OAUTH_APPLICATION_UID`, afin qu'aucune autre application OAuth ne puisse accéder à ces routes.
   def authenticate_agent
     if request.headers.include?("X-Agent-Auth-Signature")
       authenticate_agent_with_shared_secret
     else
       doorkeeper_authorize!
-      if doorkeeper_token
+      return unless doorkeeper_token
+
+      if doorkeeper_token.application.uid == ENV.fetch("RDV_INSERTION_OAUTH_APPLICATION_UID")
         @authentication_type = "OAuth"
         @current_agent = Agent.find(doorkeeper_token.resource_owner_id)
+      else
+        render(status: :unauthorized, json: {})
       end
     end
   end

--- a/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
+++ b/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
@@ -1,10 +1,18 @@
 class Api::Rdvinsertion::AgentAuthBaseController < Api::V1::AgentAuthBaseController
   private
 
-  # Cette authentification est faite via un secret partagé avec rdv-insertion qui se trouve
-  # dans la variable d'environnement `SHARED_SECRET_FOR_AGENTS_AUTH`.
-  # Ainsi nous sommes sûrs ici que les appels authentifiés sont émis par l'application rdv-insertion.
+  # L'authentification par secret partagé est faite via un secret partagé avec rdv-insertion qui se trouve
+  # dans la variable d'environnement `SHARED_SECRET_FOR_AGENTS_AUTH`. Elle a vocation à disparaître.
+  # L'authentification par OAuth sera la seule méthode d'authentification valide.
   def authenticate_agent
-    authenticate_agent_with_shared_secret
+    if request.headers.include?("X-Agent-Auth-Signature")
+      authenticate_agent_with_shared_secret
+    else
+      doorkeeper_authorize!
+      if doorkeeper_token
+        @authentication_type = "OAuth"
+        @current_agent = Agent.find(doorkeeper_token.resource_owner_id)
+      end
+    end
   end
 end

--- a/spec/requests/api/rdvinsertion/agent_auth_spec.rb
+++ b/spec/requests/api/rdvinsertion/agent_auth_spec.rb
@@ -2,7 +2,10 @@ RSpec.describe "Api::Rdvinsertion authentication" do
   let!(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
 
   context "with OAuth authentication" do
-    let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
+    let!(:rdv_insertion_oauth_application) { create(:oauth_application, uid: "rdv-insertion-app-uid") }
+    let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application: rdv_insertion_oauth_application) }
+
+    stub_env_with(RDV_INSERTION_OAUTH_APPLICATION_UID: "rdv-insertion-app-uid")
 
     it "authenticates the agent and records the correct authentication type" do
       post "/api/rdvinsertion/motif_categories", params: { name: "RSA Orientation", short_name: "rsa_orientation" },
@@ -10,6 +13,20 @@ RSpec.describe "Api::Rdvinsertion authentication" do
 
       expect(response).to have_http_status(:ok)
       expect(ApiCall.last.authentication_type).to eq "OAuth"
+    end
+  end
+
+  context "with OAuth authentication from another application" do
+    let!(:other_oauth_application) { create(:oauth_application, uid: "some-other-app-uid") }
+    let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application: other_oauth_application) }
+
+    stub_env_with(RDV_INSERTION_OAUTH_APPLICATION_UID: "rdv-insertion-app-uid")
+
+    it "returns unauthorized" do
+      post "/api/rdvinsertion/motif_categories", params: { name: "RSA Orientation", short_name: "rsa_orientation" },
+                                                 headers: oauth_client_headers(oauth_token), as: :json
+
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 

--- a/spec/requests/api/rdvinsertion/agent_auth_spec.rb
+++ b/spec/requests/api/rdvinsertion/agent_auth_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe "Api::Rdvinsertion authentication" do
+  let!(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
+
+  context "with OAuth authentication" do
+    let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
+
+    it "authenticates the agent and records the correct authentication type" do
+      post "/api/rdvinsertion/motif_categories", params: { name: "RSA Orientation", short_name: "rsa_orientation" },
+                                                 headers: oauth_client_headers(oauth_token), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(ApiCall.last.authentication_type).to eq "OAuth"
+    end
+  end
+
+  context "with shared secret authentication" do
+    let!(:shared_secret) { "S3cr3T" }
+    let!(:auth_headers) { api_auth_headers_with_shared_secret(agent, shared_secret) }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("SHARED_SECRET_FOR_AGENTS_AUTH").and_return(shared_secret)
+    end
+
+    it "authenticates the agent and records the correct authentication type" do
+      post "/api/rdvinsertion/motif_categories", params: { name: "RSA Orientation", short_name: "rsa_orientation" },
+                                                 headers: auth_headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(ApiCall.last.authentication_type).to eq "SharedSecret"
+    end
+  end
+
+  context "without authentication" do
+    it "returns unauthorized" do
+      post "/api/rdvinsertion/motif_categories", params: { name: "RSA Orientation", short_name: "rsa_orientation" }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Nous voulons enlever l'authentification par secret partagé entre nos deux applis (rdv-i et rdv-sp) pour des raisons de sécurité: si le shared secret venait à fuiter, la surface d'attaque de l'attaquant serait beaucoup trop grande.
Pour se faire on veut remplacer ce moyen d'authentification par l'authentification par oauth que supporte déjà rdv-sp. 

# Solution

Avant d'enlever l'authentification par shared secret, la première étape est de permettre l'authentification par oauth sur les endpoints spécifiques à rdv-insertion (namespacé par `api/v1/rdvinsertion`). C'est ce que j'ajoute dans cette PR.

J'ai fait une PR en parallèle sur rdv-insertion https://github.com/gip-inclusion/rdv-insertion/pull/3352 pour commencer à requêter l'API avec ces tokens d'oauth. J'y énumère les prochaines étapes nécessaires avant d'enlever complètement l'authentification par shared secret.