### PR TITLE
Refonte du sélecteur d’orga

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -60,4 +60,8 @@ module AgentsHelper
 
     !current_agent.admin_in_organisation?(current_organisation)
   end
+
+  def organisations_grouped_by_territory_for_switcher
+    current_agent.organisations.includes(:territory).ordered_by_name.group_by(&:territory)
+  end
 end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -60,12 +60,4 @@ module AgentsHelper
 
     !current_agent.admin_in_organisation?(current_organisation)
   end
-
-  def current_organisation_in_left_menu(&block)
-    if current_agent.organisations_count > 1
-      link_to(".left-submenu-account", "data-toggle" => :collapse, "aria-expanded" => "false", class: "side-menu__item", &block)
-    else
-      tag.div(class: "pt-2 pr-2 pb-2 pl-3", &block)
-    end
-  end
 end

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -104,7 +104,6 @@
     background-color: lighten($bg-leftbar, 10%);
     font-size: 1.125rem;
     border-top: 1px solid $card-border-color;
-    border-bottom: 1px solid $card-border-color;
   }
 }
 

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -153,7 +153,6 @@
 
     &--current {
       color: var(--text-default-grey);
-      font-weight: normal;
       cursor: default;
 
       &:hover,

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -44,6 +44,29 @@
 
   .current-organisation {
     font-weight: 500;
+
+    // Ce contrôle ouvre la modale de changement d'organisation : c'est un <button> (pas de
+    // navigation, pas de href) mais on veut qu'il ait le même rendu visuel qu'un lien fr-link.
+    // Le soulignement (et son épaississement au survol, icône comprise) est généré par le DSFR
+    // via un dégradé en arrière-plan appliqué au sélecteur [href], qui ne cible que les <a>.
+    // On réplique cette mécanique pour notre <button>, qui n'a pas d'attribut href.
+    button.fr-link {
+      background-image: var(--underline-img), var(--underline-img);
+      background-position:
+        var(--underline-x) 100%,
+        var(--underline-x) calc(100% - var(--underline-thickness));
+      background-repeat: no-repeat, no-repeat;
+      background-size:
+        var(--underline-hover-width) calc(var(--underline-thickness) * 2),
+        var(--underline-idle-width) var(--underline-thickness);
+      transition: background-size 0s;
+
+      &:hover {
+        color: $link-hover-color;
+        background-color: transparent;
+        --underline-hover-width: var(--underline-max-width);
+      }
+    }
   }
 
   a:not(.fr-btn):not(.fr-sidemenu__link):not(.fr-link) {
@@ -82,6 +105,71 @@
     font-size: 1.125rem;
     border-top: 1px solid $card-border-color;
     border-bottom: 1px solid $card-border-color;
+  }
+}
+
+.rdv-organisation-switcher-territory {
+  color: var(--text-mention-grey);
+  margin-bottom: 0.5rem;
+
+  & + & {
+    margin-top: 1.5rem;
+  }
+}
+
+.rdv-organisation-switcher-list {
+  margin-bottom: 1.5rem;
+
+  li + li {
+    margin-top: 0.5rem;
+  }
+
+  // Le sélecteur générique du DSFR "a[href]:hover, button:not(:disabled):hover, ..."
+  // (background-color: var(--hover-tint)) est plus spécifique qu'un simple ".foo:hover" et
+  // l'emporterait sinon sur notre propre fond de survol ; on imbrique donc dans la liste
+  // parente pour dépasser sa spécificité.
+  .rdv-organisation-switcher-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 1rem;
+    border: 1px solid var(--border-default-grey);
+    border-radius: 4px;
+    color: var(--text-action-high-blue-france);
+    font-weight: 500;
+    cursor: pointer;
+
+    // Même intensité de survol/appui que les tuiles du DSFR (mécanique .fr-enlarge-link)
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    &:active {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+
+    &--current {
+      color: var(--text-default-grey);
+      font-weight: normal;
+      cursor: default;
+
+      &:hover,
+      &:focus,
+      &:active {
+        background-color: transparent;
+      }
+    }
+  }
+}
+
+.fr-badge--icon-only {
+  padding-right: 0;
+
+  &::before {
+    margin-right: 0;
   }
 }
 

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -46,7 +46,7 @@
     font-weight: 500;
   }
 
-  a:not(.fr-btn):not(.fr-sidemenu__link) {
+  a:not(.fr-btn):not(.fr-sidemenu__link):not(.fr-link) {
     color: $menu-item;
     transition: all 0.2s;
 
@@ -75,14 +75,6 @@
       text-decoration: none;
       background-color: rgb(246, 246, 246);
     }
-  }
-
-  .menu-arrow {
-    transition: transform 0.4s;
-  }
-
-  [aria-expanded="true"] .menu-arrow {
-    transform: rotate(-180deg);
   }
 
   .current-organisation {

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -102,7 +102,8 @@
 
   .current-organisation {
     background-color: lighten($bg-leftbar, 10%);
-    font-size: 1.125rem;
+    font-size: 1.25rem;
+    font-weight: 600;
     border-top: 1px solid $card-border-color;
   }
 }

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -136,7 +136,7 @@
     padding: 1rem;
     border: 1px solid var(--border-default-grey);
     border-radius: 4px;
-    color: var(--text-action-high-blue-france);
+    color: var(--text-default-grey);
     font-weight: 500;
     cursor: pointer;
 
@@ -145,6 +145,8 @@
     &:focus {
       text-decoration: none;
       background-color: rgba(0, 0, 0, 0.05);
+      color: var(--text-action-high-blue-france);
+      border-color: var(--text-action-high-blue-france);
     }
 
     &:active {
@@ -152,8 +154,9 @@
     }
 
     &--current {
-      color: var(--text-default-grey);
+      color: var(--text-action-high-blue-france);
       cursor: default;
+      border-color: var(--text-action-high-blue-france);
 
       &:hover,
       &:focus,

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -5,12 +5,17 @@ aside.left-side-menu-wrapper
     .current-organisation
       .fr-pt-2w.fr-pr-2w.fr-pb-2w.fr-pl-3w.d-flex.align-items-center
         div.d-flex.flex-column
-          = current_organisation.name
+          span.d-flex.align-items-center
+            = current_organisation.name
+            - if current_agent.admin_in_organisation?(current_organisation)
+              span.fr-badge.fr-badge--sm.fr-badge--pink-tuile.fr-icon-user-setting-fill.fr-badge--icon-left.fr-badge--icon-only.fr-ml-1w[title="Vous administrez cette organisation"]
+                span.fr-sr-only Administrateur
           - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
             span.fr-text--xs.fr-mb-0= current_agent.services_short_names
       - if current_agent.organisations_count > 1
         .fr-pl-3w.fr-pb-2w.fr-mt-n2w
-          = link_to "Changer d'organisation", admin_organisations_path, class: "fr-link fr-link--icon-right fr-icon-arrow-right-line fr-link--xs"
+          button.fr-link.fr-link--icon-right.fr-icon-arrow-right-line.fr-link--xs[data-fr-opened="false" aria-controls="organisation-switcher-modal" type="button"]
+            | Changer d'organisation
 
     - if content_for? :side_nav_menu
       = yield :side_nav_menu

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -7,9 +7,6 @@ aside.left-side-menu-wrapper
         div.d-flex.flex-column
           span.d-flex.align-items-center
             = current_organisation.name
-            - if current_agent.admin_in_organisation?(current_organisation)
-              span.fr-badge.fr-badge--sm.fr-badge--pink-tuile.fr-icon-user-setting-fill.fr-badge--icon-left.fr-badge--icon-only.fr-ml-1w[title="Vous administrez cette organisation"]
-                span.fr-sr-only Administrateur
           - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
             span.fr-text--xs.fr-mb-0= current_agent.services_short_names
       - if current_agent.organisations_count > 1

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -3,7 +3,7 @@ aside.left-side-menu-wrapper
     .fr-p-2w.d-flex.justify-content-center
       = link_to "Trouver un RDV", search_rdv_slot_url_with(@user), class: "fr-btn"
     .current-organisation
-      .fr-pt-2w.fr-pr-2w.fr-pb-2w.fr-pl-3w.d-flex.align-items-center
+      .fr-pt-2w.fr-pr-2w.fr-pb-2w.fr-pl-2w.d-flex.align-items-center
         div.d-flex.flex-column
           span.d-flex.align-items-center
             = current_organisation.name
@@ -13,7 +13,7 @@ aside.left-side-menu-wrapper
           - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
             span.fr-text--xs.fr-mb-0= current_agent.services_short_names
       - if current_agent.organisations_count > 1
-        .fr-pl-3w.fr-pb-2w.fr-mt-n2w
+        .fr-pl-2w.fr-pb-2w.fr-mt-n2w
           button.fr-link.fr-link--icon-right.fr-icon-arrow-right-line.fr-link--xs[data-fr-opened="false" aria-controls="organisation-switcher-modal" type="button"]
             | Changer d'organisation
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -3,17 +3,14 @@ aside.left-side-menu-wrapper
     .fr-p-2w.d-flex.justify-content-center
       = link_to "Trouver un RDV", search_rdv_slot_url_with(@user), class: "fr-btn"
     .current-organisation
-      = current_organisation_in_left_menu do
-        .d-flex.justify-content-between.w-100
-          div.d-flex.align-items-center
-            div.d-flex.flex-column
-              = current_organisation.name
-              - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
-                span.fr-text--xs.fr-mb-0= current_agent.services_short_names
-          - if current_agent.organisations_count > 1
-            div.d-flex.align-items-center
-              = icon("fr-icon-arrow-down-s-line", class: "menu-arrow")
-      = render "layouts/left_menu/organisation_switcher"
+      .fr-pt-2w.fr-pr-2w.fr-pb-2w.fr-pl-3w.d-flex.align-items-center
+        div.d-flex.flex-column
+          = current_organisation.name
+          - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
+            span.fr-text--xs.fr-mb-0= current_agent.services_short_names
+      - if current_agent.organisations_count > 1
+        .fr-pl-3w.fr-pb-2w.fr-mt-n2w
+          = link_to "Changer d'organisation", admin_organisations_path, class: "fr-link fr-link--icon-right fr-icon-arrow-right-line fr-link--xs"
 
     - if content_for? :side_nav_menu
       = yield :side_nav_menu

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -39,4 +39,6 @@ html lang="fr"
               = yield
 
       = render "layouts/agent_footer"
+    - if current_agent.organisations_count > 1
+      = render "layouts/left_menu/organisation_switcher_modal"
     #modal-holder

--- a/app/views/layouts/left_menu/_organisation_switcher.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher.html.slim
@@ -1,8 +1,0 @@
-ul.list-unstyled.left-submenu-account.collapse
-  - if current_agent.organisations_count > 10
-    li
-      = link_to "Changer d'organisation", admin_organisations_path, class: "side-menu__item side-menu__item--small pl-4"
-  - else
-    - current_agent.organisations.ordered_by_name.each do |organisation|
-      li
-        = link_to organisation.name, admin_organisation_planning_agenda_path(organisation), class: "side-menu__item side-menu__item--small #{'active' if organisation == current_organisation} pl-4 "

--- a/app/views/layouts/left_menu/_organisation_switcher_modal.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher_modal.html.slim
@@ -16,7 +16,7 @@ dialog#organisation-switcher-modal.fr-modal[aria-labelledby="organisation-switch
               - if multiple_territories
                 p.fr-text--sm.rdv-organisation-switcher-territory
                   | Espace : #{territory.name_for_agent}
-              ul.list-unstyled.rdv-organisation-switcher-list
+              ul.fr-raw-list.rdv-organisation-switcher-list
                 - organisations.each do |organisation|
                   li
                     - if organisation == current_organisation

--- a/app/views/layouts/left_menu/_organisation_switcher_modal.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher_modal.html.slim
@@ -23,15 +23,9 @@ dialog#organisation-switcher-modal.fr-modal[aria-labelledby="organisation-switch
                       .rdv-organisation-switcher-item.rdv-organisation-switcher-item--current
                         span.d-flex.align-items-center
                           = organisation.name
-                          - if current_agent.admin_in_organisation?(organisation)
-                            span.fr-badge.fr-badge--sm.fr-badge--pink-tuile.fr-icon-user-setting-fill.fr-badge--icon-left.fr-badge--icon-only.fr-ml-1w[title="Vous administrez cette organisation"]
-                              span.fr-sr-only Administrateur
                         span.fr-badge.fr-badge--blue-cumulus.fr-badge--sm.fr-badge--no-icon ORGANISATION ACTUELLE
                     - else
                       = link_to admin_organisation_planning_agenda_path(organisation), class: "rdv-organisation-switcher-item" do
                         span.d-flex.align-items-center
                           = organisation.name
-                          - if current_agent.admin_in_organisation?(organisation)
-                            span.fr-badge.fr-badge--sm.fr-badge--pink-tuile.fr-icon-user-setting-fill.fr-badge--icon-left.fr-badge--icon-only.fr-ml-1w[title="Vous administrez cette organisation"]
-                              span.fr-sr-only Administrateur
                         = icon("fr-icon-arrow-right-s-line")

--- a/app/views/layouts/left_menu/_organisation_switcher_modal.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher_modal.html.slim
@@ -1,0 +1,37 @@
+- organisations_by_territory = organisations_grouped_by_territory_for_switcher
+- multiple_territories = organisations_by_territory.size > 1
+
+dialog#organisation-switcher-modal.fr-modal[aria-labelledby="organisation-switcher-modal-title" data-fr-concealing-backdrop="true"]
+  .fr-container.fr-container--fluid.fr-container-md
+    .fr-grid-row.fr-grid-row--center
+      .fr-col-12.fr-col-md-8.fr-col-lg-6
+        .fr-modal__body
+          .fr-modal__header
+            button.fr-btn--close.fr-btn[aria-controls="organisation-switcher-modal" title="Fermer" type="button"]
+              | Fermer
+          .fr-modal__content
+            h2#organisation-switcher-modal-title.fr-modal__title
+              | Choisissez votre organisation
+            - organisations_by_territory.each do |territory, organisations|
+              - if multiple_territories
+                p.fr-text--sm.rdv-organisation-switcher-territory
+                  | Espace : #{territory.name_for_agent}
+              ul.list-unstyled.rdv-organisation-switcher-list
+                - organisations.each do |organisation|
+                  li
+                    - if organisation == current_organisation
+                      .rdv-organisation-switcher-item.rdv-organisation-switcher-item--current
+                        span.d-flex.align-items-center
+                          = organisation.name
+                          - if current_agent.admin_in_organisation?(organisation)
+                            span.fr-badge.fr-badge--sm.fr-badge--pink-tuile.fr-icon-user-setting-fill.fr-badge--icon-left.fr-badge--icon-only.fr-ml-1w[title="Vous administrez cette organisation"]
+                              span.fr-sr-only Administrateur
+                        span.fr-badge.fr-badge--blue-cumulus.fr-badge--sm.fr-badge--no-icon ORGANISATION ACTUELLE
+                    - else
+                      = link_to admin_organisation_planning_agenda_path(organisation), class: "rdv-organisation-switcher-item" do
+                        span.d-flex.align-items-center
+                          = organisation.name
+                          - if current_agent.admin_in_organisation?(organisation)
+                            span.fr-badge.fr-badge--sm.fr-badge--pink-tuile.fr-icon-user-setting-fill.fr-badge--icon-left.fr-badge--icon-only.fr-ml-1w[title="Vous administrez cette organisation"]
+                              span.fr-sr-only Administrateur
+                        = icon("fr-icon-arrow-right-s-line")

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_button("Enregistrer")
 
       expect_page_title("Agents de Organisation n°1")
-      expect(page).to have_content("Administrateur", count: 2)
+      within("table") { expect(page).to have_content("Administrateur", count: 2) }
 
       click_link "PATRICK Tony"
       click_link("Supprimer le compte")


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6568.osc-secnum-fr1.scalingo.io/)

# Contexte

Avec le trio navigation, nous sommes partis du constat suivant : le sélecteur d’organisation prenait beaucoup de place et il n’était pas très accessible.

# Solution

On propose donc de refondre le changement d’organisation, en utilisant une modale.
Suite à une maquette de @Teodora-Stanki 

C’est une première version qui mérite d’être commenté et amendé.

## Captures d'écran

<img width="342" height="212" alt="image" src="https://github.com/user-attachments/assets/d28e0d9f-76e6-4dfe-bc3c-6487a5760a78" />

<img width="716" height="578" alt="image" src="https://github.com/user-attachments/assets/cbeabc54-b19c-4193-9bb8-d676b632765c" />

