### PR TITLE
Ajout de « Réservation en ligne » dans le menu agent

### DIFF
--- a/app/controllers/admin/organisations/online_booking/motifs_controller.rb
+++ b/app/controllers/admin/organisations/online_booking/motifs_controller.rb
@@ -1,6 +1,7 @@
 class Admin::Organisations::OnlineBooking::MotifsController < AgentAuthController
   before_action :set_organisation
   before_action :set_motif
+  before_action { @current_menu_item = :menu_online_booking }
 
   def show; end
 

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -42,10 +42,12 @@ module AgentsHelper
 
   def active_menu_item
     case controller_name
-    when "lieux", "agents", "invitations", "motifs", "online_bookings", "configurations", "organisations"
+    when "lieux", "agents", "invitations", "motifs", "configurations", "organisations"
       :menu_settings
     when "rdvs_collectifs", "motif_selections"
       :menu_rdv_collectifs
+    when "online_bookings"
+      :menu_online_booking
     when "users", "merge_users", "referent_assignations"
       :menu_users
     when "rdvs"

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -25,6 +25,9 @@ aside.left-side-menu-wrapper
       = render(DsfrComponent::SideMenuComponent.new(title: "Menu", html_attributes: {id: "menu"} )) do |menu|
         ruby:
           menu.with_item(title: safe_join([icon("fr-icon-calendar-event-line", class: "fr-icon--sm fr-mr-1w"), "Planning"]), path: admin_organisation_planning_agenda_path(current_organisation, **query_params), current_page: active_item == :menu_planning)
+        - if current_agent.admin_in_organisation?(current_organisation)
+          - menu.with_item(title: safe_join([icon("fr-icon-global-line", class: "fr-icon--sm fr-mr-1w"), "Réservation en ligne"]), path: admin_organisation_online_booking_path(current_organisation), current_page: active_item == :menu_online_booking)
+        ruby:
           menu.with_item(title: safe_join([icon("fr-icon-group-line", class: "fr-icon--sm fr-mr-1w"), "Usagers"]), path: admin_organisation_users_path(current_organisation), current_page: active_item == :menu_users)
           menu.with_item(title: safe_join([icon("fr-icon-survey-line", class: "fr-icon--sm fr-mr-1w"), "Liste des RDV"]), path: admin_organisation_rdvs_path(current_organisation), current_page: active_item == :menu_liste_rdvs)
           menu.with_item(title: safe_join([icon("fr-icon-team-line", class: "fr-icon--sm fr-mr-1w"), "RDV collectifs"]), path: admin_organisation_rdvs_collectifs_path(current_organisation), current_page: active_item == :menu_rdv_collectifs)

--- a/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     doc.add_screenshot(page, text: "J'ouvre le menu de configuration et je clique sur la Réservation en ligne", wait_for: "Réservation en ligne")
 
-    click_on "Réservation en ligne"
+    within("#main") { click_on "Réservation en ligne" }
 
     doc.add_screenshot(page, text: "Je sélectionne mon motif et je valide", wait_for: "Vous gardez le contrôle")
 


### PR DESCRIPTION
# Contexte

On souhaite rendre les paramètres de la réservation en ligne, plus découvrable.

# Solution

On ajoute donc une entrée dans le menu pour les agents admin, qui ont accès à cet écran.

Avec le trio navigation, nous sommes en train de regarder pour éventuellement épurer le menu, mettre des séparateurs,… mais nous regarderons ce sujet dans un second temps.

## Captures d'écran

<img width="744" height="671" alt="image" src="https://github.com/user-attachments/assets/42963d71-ce9e-47b2-bb4d-2a4c404cb87a" />
