### PR TITLE
Petit allègement de la vue planning

### DIFF
--- a/app/views/admin/planning/_planning_agents_select.html.slim
+++ b/app/views/admin/planning/_planning_agents_select.html.slim
@@ -1,4 +1,4 @@
-#planning_agents_select.container-fluid.fr-px-2w[style="background-color: white; border-bottom: 1px solid #EEE;"]
+#planning_agents_select.container-fluid.fr-px-2w[style="background-color: white"]
   = render "layouts/flash", flash_types: %i[login]
   = content_for :onboarding_banner_start
   .rdv-display-flex.rdv-gap-05rem.rdv-align-items-center.rdv-flex-wrap-wrap.rdv-justify-content-space-between.fr-py-3w


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1424" height="448" alt="Screenshot 2026-08-06 at 11 29 25" src="https://github.com/user-attachments/assets/e673c9a6-17a0-4887-88b0-80d5f17897a0" />|<img width="1424" height="444" alt="Screenshot 2026-08-06 at 11 30 44" src="https://github.com/user-attachments/assets/a9d8ed2c-66f2-4c56-b241-4cce7432f25b" />

Vu avec Mehdi : on enlève le séparateur entre le select d'agent et le select de page (Agenda/Po/Indispo), puisque les deux sont liés. Ça enlève un peu de bruit visuel, c'est plus léger, on adore.