### PR TITLE
Supprimer un paramètre de l'endpoint d'update des webhooks

### DIFF
--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -11,10 +11,11 @@ class Api::V1::WebhookEndpointsController < Api::V1::AgentAuthBaseController
   end
 
   def create
-    params.permit(:target_url, :secret, :organisation_id, subscriptions: [])
+    create_permitted_params = params.permit(:target_url, :secret, :organisation_id, subscriptions: [])
 
-    @webhook_endpoint = WebhookEndpoint.new(webhook_endpoint_params)
+    @webhook_endpoint = WebhookEndpoint.new(create_permitted_params)
     authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
+
     @webhook_endpoint.save!
     TriggerWebhookJob.perform_later(@webhook_endpoint.id) unless trigger_disabled
     render_record @webhook_endpoint

--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -11,6 +11,8 @@ class Api::V1::WebhookEndpointsController < Api::V1::AgentAuthBaseController
   end
 
   def create
+    params.permit(:target_url, :secret, :organisation_id, subscriptions: [])
+
     @webhook_endpoint = WebhookEndpoint.new(webhook_endpoint_params)
     authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
     @webhook_endpoint.save!
@@ -19,7 +21,9 @@ class Api::V1::WebhookEndpointsController < Api::V1::AgentAuthBaseController
   end
 
   def update
-    @webhook_endpoint.update!(webhook_endpoint_params)
+    update_permitted_params = params.permit(:target_url, :secret, subscriptions: [])
+
+    @webhook_endpoint.update!(update_permitted_params)
     TriggerWebhookJob.perform_later(@webhook_endpoint.id) unless trigger_disabled
     render_record @webhook_endpoint
   end
@@ -37,14 +41,6 @@ class Api::V1::WebhookEndpointsController < Api::V1::AgentAuthBaseController
 
   def set_organisation
     @organisation = Organisation.find(params[:organisation_id])
-  end
-
-  def permitted_params
-    params.permit(:target_url, :secret, :organisation_id, :trigger, subscriptions: [])
-  end
-
-  def webhook_endpoint_params
-    permitted_params.except(:trigger)
   end
 
   def pundit_user

--- a/spec/requests/api/v1/swagger_doc/webhook_endpoints_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/webhook_endpoints_request_spec.rb
@@ -167,16 +167,12 @@ RSpec.describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
       let(:secret) { "abc123" }
 
       response 200, "Met à jour et renvoie un webhook_endpoint" do
-        let(:other_organisation) { create(:organisation, territory: territory) }
-        let(:organisation_id) { other_organisation.id }
-
         schema "$ref" => "#/components/schemas/webhook_endpoint_with_root"
 
         run_test!
 
         specify do
           expect(webhook_endpoint.reload).to have_attributes(
-            organisation: other_organisation,
             target_url: target_url,
             secret: secret,
             subscriptions: %w[rdv user user_profile organisation motif lieu agent agent_role]


### PR DESCRIPTION
Voir https://docs.numerique.gouv.fr/docs/3e6e8de6-c9d3-4042-8e7f-47207b662689/

J'ai vérifié que ce paramètre n'était pas utilisé par les clients qui appellent cette api.