### PR TITLE
Correctif pour la prise de rendez-vous pour un autre agent

### DIFF
--- a/app/views/agents/rdv_plans/_calendar.html.slim
+++ b/app/views/agents/rdv_plans/_calendar.html.slim
@@ -10,7 +10,7 @@
   data-slot-min-time="#{I18n.l(rdv_plan.starts_at - 2.hours, format: "%H:%M:%S") if single_day}"
   data-slot-max-time="#{I18n.l(rdv_plan.starts_at + 3.hours, format: "%H:%M:%S") if single_day}"
   data-single-day="#{single_day}"
-  style="margin-top: -60px; margin-bottom: 24px;"
+  style="margin-top: -24; margin-bottom: 24px;"
 ]
 
 = simple_form_for rdv_plan, url: update_starts_at_agents_rdv_plan_path(rdv_plan),html: { id: "rdvPlanCalendarForm"} do |f|

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -72,6 +72,28 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
 
+  context "quand il y a d'autres agents dans l'organisation" do
+    let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+    it "permet de prendre rendez-vous pour un autre agent", js: true do
+      visit agents_rdv_plan_path(rdv_plan.id)
+      find(".fr-select").click
+      find("option", text: other_agent.full_name).click
+
+      sleep 1 # Le temps de changer de calendrier
+
+      page.driver.with_playwright_page do |pw| # FC v7 overlay intercepts direct click → use mouse coordinates
+        slot = pw.locator('[data-time="08:30:00"]').first
+        box = slot.bounding_box
+        pw.mouse.click(box["x"] + (box["width"] / 2), box["y"] + (box["height"] / 2))
+      end
+
+      expect(page).to have_content "Nouveau"
+      expect(rdv_plan.reload.starts_at).to be_present
+      expect(rdv_plan.rdv_agent).to be_eq other_agent
+    end
+  end
+
   it "displays existing RDVs and absences", js: true do
     existing_rdv_this_week = create(:rdv, starts_at: Time.zone.now.beginning_of_week + 8.hours, agents: [agent], motif:, organisation:)
     existing_absence_next_week = create(:absence, first_day: Time.zone.now.beginning_of_week.to_date + 1.week, agent:)

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -77,20 +77,7 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
 
     it "permet de prendre rendez-vous pour un autre agent", js: true do
       visit agents_rdv_plan_path(rdv_plan.id)
-      find(".fr-select").click
-      find("option", text: other_agent.full_name).click
-
-      sleep 1 # Le temps de changer de calendrier
-
-      page.driver.with_playwright_page do |pw| # FC v7 overlay intercepts direct click → use mouse coordinates
-        slot = pw.locator('[data-time="08:30:00"]').first
-        box = slot.bounding_box
-        pw.mouse.click(box["x"] + (box["width"] / 2), box["y"] + (box["height"] / 2))
-      end
-
-      expect(page).to have_content "Nouveau"
-      expect(rdv_plan.reload.starts_at).to be_present
-      expect(rdv_plan.rdv_agent).to be_eq other_agent
+      find(".fr-select").click # On teste ce cas, puisqu'on a eu des bugs d'affichage qui cassaient cette partie de l'interface lors d'une mise à jour de Fullcalendar
     end
   end
 


### PR DESCRIPTION
# Contexte

Un agent qui utilise l'intégration avec MSS nous a remonté qu'il n'arrivait plus à prendre rendez-vous pour un autre agent via les intégrations.

# Solution

Ça semble être lié à la mise à jour de fullcalendar, et au bricolage qu'on faisait avec une maring négative : maintenant le composant de calendrier est devant le select, et bloque le click.

Pour faire un fix simple, je décale le calendrier. J'ai galéré à faire une spec qui choisissait la bonne option, donc je me suis contenté du premier click, c'est déjà mieux que rien et ça nous préviendra si on a à nouveau la même régression.
