### PR TITLE
Logguer les paramètres utilisées dans les ApiCalls

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -140,12 +140,25 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       host: request.host,
     }
 
+    param_names = request.query_parameters.keys
+
+    if request.raw_post.present?
+      parsed_params = begin
+        JSON.parse(request.raw_post)
+      rescue StandardError
+        {}
+      end
+
+      param_names += parsed_params.keys
+    end
+
     ApiCall.create!(
       raw_http: raw_http,
       controller_name: controller_name,
       action_name: action_name,
       agent_id: current_agent.id,
-      authentication_type: @authentication_type
+      authentication_type: @authentication_type,
+      param_names: param_names
     )
   rescue StandardError => e
     Sentry.capture_exception(e, extra: {

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -454,6 +454,7 @@ tables:
       - action_name
       - agent_id
       - authentication_type
+      - param_names
 
   - table_name: exports
     non_anonymized_column_names:

--- a/db/migrate/20260812083736_add_api_call_params.rb
+++ b/db/migrate/20260812083736_add_api_call_params.rb
@@ -1,0 +1,5 @@
+class AddApiCallParams < ActiveRecord::Migration[8.0]
+  def change
+    add_column :api_calls, :param_names, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_30_124356) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_12_083736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -204,6 +204,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_30_124356) do
     t.string "action_name", null: false
     t.bigint "agent_id", null: false
     t.string "authentication_type"
+    t.string "param_names", default: [], array: true
   end
 
   create_table "blog_posts", force: :cascade do |t|

--- a/spec/requests/api/v1/api_call_logging_spec.rb
+++ b/spec/requests/api/v1/api_call_logging_spec.rb
@@ -1,13 +1,26 @@
 RSpec.describe "On enregistre les appels à l'api pour mieux comprendre qui s'en sert et comment" do
   context "with OAuth authentication" do
     let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
+    let(:organisation) { create(:organisation) }
     let(:agent) do
-      create(:agent, basic_role_in_organisations: [create(:organisation)])
+      create(:agent, basic_role_in_organisations: [organisation])
     end
+
+    let(:user) { create(:user, organisations: [organisation]) }
 
     it "records the correct authentication type" do
       get "/api/v1/absences", headers: oauth_client_headers(oauth_token), as: :json
       expect(ApiCall.last.authentication_type).to eq "OAuth"
+    end
+
+    it "records the name of the params so that we can know which ones are used without saving personnal data" do
+      post "/api/v1/users", headers: oauth_client_headers(oauth_token), params: { first_name: "Bob", organisation_ids: [organisation.id] }, as: :json
+
+      expect(ApiCall.last.param_names).to eq %w[first_name organisation_ids]
+
+      get "/api/v1/users", headers: oauth_client_headers(oauth_token), params: { ids: [123] }, as: :json
+
+      expect(ApiCall.last.param_names).to eq ["ids"]
     end
   end
 end


### PR DESCRIPTION
# Contexte

Pour mieux comprendre comment est utilisée notre api, ça serait pratique de savoir quels paramètres sont utilisés pour quels appels. On vient de lire le code source de RDV Insertion et Mon Suivi Social avec François pour mieux comprendre les updates sur les users. Si on avait eu cette info dans metabase, on aurait pu aller beaucoup plus vite.

# Solution

On loggue le nom des paramètres, mais pas leur valeur pour éviter de logguer des données personnelles.

