### PR TITLE
Clarifier les consignes sur la page de détails du motif

### DIFF
--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -9,8 +9,8 @@ ul#motif_tabs.nav.nav-tabs.mt-3[role="tablist"]
     button#tab_notifs_et_instructions.nav-link[data-toggle="tab" data-target="#notifs_et_instructions" type="button" role="tab" aria-controls="notifs_et_instructions" aria-selected="false"]
       | Options avancées
 
-.row.justify-content-center
-  .col-md-12.col-lg-8
+.fr-grid-row.justify-content-center
+  .fr-col-md-12.fr-col-lg-8
     .tab-content.mt-4
       #configuration_principale.tab-pane.fade.show.active[role="tabpanel" aria-labelledby="tab_configuration_principale"]
         = render "admin/motifs/form/configuration_principale", f: f, motif: motif
@@ -19,9 +19,6 @@ ul#motif_tabs.nav.nav-tabs.mt-3[role="tablist"]
       #notifs_et_instructions.tab-pane.fade[role="tabpanel" aria-labelledby="tab_notifs_et_instructions"]
         = render "admin/motifs/form/advanced_options", f: f, motif: motif, rdvi_mode: rdvi_mode
 
-    .row.mb-5
-      - if motif.persisted?
-        .col.text-left
-          = link_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(motif.organisation, motif), method: :delete, class: "fr-btn fr-btn--tertiary", data: { confirm: t("admin.motifs.actions.destroy_confirm") }
-      .col.text-right
+    .fr-grid-row.mb-5
+      .fr-col.text-right
         = f.submit((motif.new_record? ? "Créer le motif" : "Enregistrer"), class: "fr-btn")

--- a/app/views/admin/motifs/_instruction_for_rdv_recap.html.slim
+++ b/app/views/admin/motifs/_instruction_for_rdv_recap.html.slim
@@ -1,0 +1,10 @@
+/# locals: (motif: )
+
+- if motif.instruction_for_rdv.blank?
+  p.fr-mt-4w
+    i.fr-text-mention--grey Pas d'instructions à afficher après la prise de rendez-vous
+- else
+  p.fr-mt-4w
+    b Instructions à afficher après la prise de rendez-vous
+  .fr-highlight.fr-mb-2w
+    i= instruction_for_rdv_to_html(motif)

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -3,9 +3,11 @@
 tr
   td.fr-pr-0.fr-pt-2w.fr-pb-0
     span.fr-icon-circle-fill style="color: #{motif.color};" &nbsp;
-  td
-    = link_to motif.name, admin_organisation_motif_path(motif.organisation, motif)
-    = motif_badges(motif, only: %i[for_secretariat follow_up collectif])
+  td.fr-p-0
+    / On agrandit la taille du lien pour faciliter le click
+    = link_to admin_organisation_motif_path(motif.organisation, motif), style: "width: 100%; min-height: 48px;", class: "fr-btn fr-btn--tertiary-no-outline fr-m-0" do
+      =  motif.name
+      = motif_badges(motif, only: %i[for_secretariat follow_up collectif])
   td
     = motif_badges(motif, only: %i[bookable_by_everyone bookable_by_agents_and_prescripteurs bookable_by_invited_users])
   - if display_sectorisation_level?

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -1,7 +1,7 @@
 - motif_policy = policy(motif, policy_class: Agent::MotifPolicy)
 
 tr
-  td.fr-pr-0.fr-pt-2w.fr-pb-0
+  td.fr-pr-0.fr-py-2w.fr-pb-0
     span.fr-icon-circle-fill style="color: #{motif.color};" &nbsp;
   td.fr-p-0
     / On agrandit la taille du lien pour faciliter le click

--- a/app/views/admin/motifs/_restriction_for_rdv_recap.html.slim
+++ b/app/views/admin/motifs/_restriction_for_rdv_recap.html.slim
@@ -1,0 +1,10 @@
+/# locals: (motif: )
+
+- if motif.restriction_for_rdv.blank?
+  p
+    i.fr-text-mention--grey Pas d'instructions à accepter avant la prise de rendez-vous
+- else
+  p
+    b Instructions à accepter avant la prise de rendez-vous
+  .fr-highlight.fr-mb-2w
+    i= restriction_for_rdv_to_html(motif)

--- a/app/views/admin/motifs/form/_advanced_options.html.slim
+++ b/app/views/admin/motifs/form/_advanced_options.html.slim
@@ -1,17 +1,4 @@
 .card
-  .card-body.pt-4
-    ruby:
-      visibility_types = %i[visible_and_notified visible_and_not_notified invisible].map do |value|
-        {
-          value:,
-          checked: @motif.visibility_type == value.to_s || (motif.new_record? && value == :visible_and_notified),
-          label: sanitize(Motif.human_attribute_value(:visibility_type, value, context: :html)),
-          hint: Motif.human_attribute_value(:visibility_type, value, context: rdvi_mode ? :hint_rdv_insertion : :hint),
-        }
-      end
-    = f.dsfr_radio_buttons :visibility_type, visibility_types, hint: "Si ce motif est sensible (par exemple s'il lié à des services médicaux ou sociaux), vous pouvez désactiver les notifications pour protéger la confidentialité de vos usagers."
-
-.card
   .card-body
     fieldset.fr-fieldset
       legend.fr-fieldset__legend--regular.fr_fieldset__legend
@@ -35,6 +22,19 @@
                 placeholder: "Laissez vide si vous ne souhaitez pas afficher de messager d’avertissement.",
                 rows: 5,
                 hint: link_to("Voir un exemple", image_path("motif_form/custom_cancel_warning_message.png"), target: "_blank")
+
+.card
+  .card-body.pt-4
+    ruby:
+      visibility_types = %i[visible_and_notified visible_and_not_notified invisible].map do |value|
+        {
+          value:,
+          checked: @motif.visibility_type == value.to_s || (motif.new_record? && value == :visible_and_notified),
+          label: sanitize(Motif.human_attribute_value(:visibility_type, value, context: :html)),
+          hint: Motif.human_attribute_value(:visibility_type, value, context: rdvi_mode ? :hint_rdv_insertion : :hint),
+        }
+      end
+    = f.dsfr_radio_buttons :visibility_type, visibility_types, hint: "Si ce motif est sensible (par exemple s'il lié à des services médicaux ou sociaux), vous pouvez désactiver les notifications pour protéger la confidentialité de vos usagers."
 
 .card
   .card-body

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -24,11 +24,11 @@
       .fr-col-md-6= f.dsfr_input_field :color, :color_field, label: "Couleur associée", style: "height: 2.5rem"
 
 .card
-  .card-body
+  .card-body.fr-pb-0
     = render partial: "admin/motifs/form/location_types", locals: { f: f, disabled: motif.rdvs.any? }
 
 .card
-  .card-body
+  .card-body.fr-pb-0
     - disabled = motif.rdvs.any?
 
     ruby:
@@ -38,5 +38,5 @@
       ]
     = f.dsfr_radio_buttons :collectif, collectif_options, disabled: disabled, rich: true
     - if disabled
-      = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
+      = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-3w" } do
         | Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le nombre de participants

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -18,7 +18,7 @@
       - available_services = (current_territory.services.reject(&:secretariat?) + [motif.service].compact).sort.uniq
       - if available_services.any? || motif.service_id.present?
         .fr-col-md-12
-          = f.dsfr_select :service_id, available_services.collect { |service| [service.name, service.id] }, { include_blank: "Aucun" }, label: "Service associé", hint: "Optionnel"
+          = f.dsfr_select :service_id, available_services.collect { |service| [service.name, service.id] }, { include_blank: "Aucun" }, label: "Service associé", hint: "Facultatif"
       .fr-col-md-6= f.dsfr_number_field :default_duration_in_min, label: "Durée du RDV (en minutes)"
       // Le DSFR ne propose pas d’input color, on utilise donc le champ classique avec le style DSFR pour lequel on fixe la hauteur.
       .fr-col-md-6= f.dsfr_input_field :color, :color_field, label: "Couleur associée", style: "height: 2.5rem"

--- a/app/views/admin/motifs/form/_location_types.html.slim
+++ b/app/views/admin/motifs/form/_location_types.html.slim
@@ -8,7 +8,7 @@
               hint: sanitize(Motif.human_attribute_value(:location_type, value, context: :hint), scrubber: :prune),
       }
     end
-  = f.dsfr_radio_buttons :location_type, location_types, disabled:, "data-action": "change->motif-form#refreshSections", "data-motif-form-target": "locationTypeRadios", hint: "Choisissez le type du rendez-vous", rich: true
+  = f.dsfr_radio_buttons :location_type, location_types, disabled:, "data-action": "change->motif-form#refreshSections", "data-motif-form-target": "locationTypeRadios", hint: "Choisissez le type du rendez-vous", rich: true, class: "fr-mb-0"
   - motif = f.object
   - if motif.persisted?
     p.fr-text-mention--grey.font-14
@@ -18,5 +18,5 @@
       | .
 
 - if disabled
-  = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
+  = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-3w" } do
     | Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le type

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -88,6 +88,7 @@
             Motif.human_attribute_name(:follow_up_short), \
             motif_option_activated(@motif, :follow_up), \
             hint: Motif.human_attribute_name(:follow_up_hint)
+
           = motif_attribute_row \
             Motif.human_attribute_name(:for_secretariat_short), \
             motif_option_activated(@motif, :for_secretariat), \

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -76,24 +76,22 @@
             | Options avancées
         .fr-collapse id="options-avancees"
 
+          b= @motif.human_attribute_value(:visibility_type, context: :html)
+
+          .fr-text-mention--grey
+            = @motif.human_attribute_value(:visibility_type, context: :hint)
+            - if current_organisation.rdv_insertion?
+              br
+              span= @motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
+
           = motif_attribute_row \
             Motif.human_attribute_name(:follow_up_short), \
             motif_option_activated(@motif, :follow_up), \
-            hint: Motif.human_attribute_name(:follow_up_hint), margin: false
+            hint: Motif.human_attribute_name(:follow_up_hint)
           = motif_attribute_row \
             Motif.human_attribute_name(:for_secretariat_short), \
             motif_option_activated(@motif, :for_secretariat), \
             hint: Motif.human_attribute_name(:for_secretariat_hint)
-          hr
-
-          = motif_attribute_row(Motif.human_attribute_name(:visibility_type), margin: false) do
-            div= sanitize(@motif.human_attribute_value(:visibility_type, context: :html))
-
-            div.fr-text-mention--grey
-              = @motif.human_attribute_value(:visibility_type, context: :hint)
-              - if current_organisation.rdv_insertion?
-                br
-                span= @motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
 
     - if @motif_policy.edit? || @motif_policy.destroy?
       .card.mt-2

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -51,21 +51,30 @@
           = dsfr_link_to "Voir les détails de réservation en ligne", admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-icon-arrow-right-line fr-link--icon-right"
 
     .card.mt-2
+      .card-body
+        h2.fr-h5 Consignes à destination de l'usager
+
+        = render "admin/motifs/instruction_for_rdv_recap", motif: @motif
+
+        p.fr-mt-4w
+          b =Motif.human_attribute_name(:custom_cancel_warning_message)
+
+          = icon("fr-icon-information-line", "aria-describedby" => "cancel-warning-message-tooltip", class: "fr-icon--sm fr-ml-1w")
+          span.fr-tooltip.fr-placement#cancel-warning-message-tooltip role="tooltip"
+            = Motif.human_attribute_name(:custom_cancel_warning_message_hint)
+        - if @motif.custom_cancel_warning_message.blank?
+          p
+            i.fr-text-mention--grey Pas d'instructions à afficher quand l'usager annule le rendez-vous
+        - else
+          .fr-highlight.fr-mb-2w
+             = @motif.custom_cancel_warning_message
+
+    .card.mt-2
       .rdv-accordion-card.fr-accordion
         h2.fr-accordion__title
           button.fr-h5.fr-accordion__btn aria-expanded="false" aria-controls="options-avancees"
             | Options avancées
         .fr-collapse id="options-avancees"
-          = motif_attribute_row \
-            Motif.human_attribute_name(:instruction_for_rdv_short), \
-            instruction_for_rdv_to_html(@motif), \
-            hint: Motif.human_attribute_name(:instruction_for_rdv_hint)
-          = motif_attribute_row \
-            Motif.human_attribute_name(:custom_cancel_warning_message), \
-            @motif.custom_cancel_warning_message, \
-            hint: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
-
-          hr
 
           = motif_attribute_row \
             Motif.human_attribute_name(:follow_up_short), \

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -79,21 +79,8 @@
           .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
             h2.fr-h4 Consignes pour les usagers
             = link_to "Modifier", edit_instructions_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
-          - if @motif.restriction_for_rdv.blank?
-            p
-              i Pas d'instructions à accepter avant la prise de rendez-vous
-          - else
-            p Instructions à accepter avant la prise de rendez-vous :
-            .fr-highlight.fr-mb-2w
-              i= restriction_for_rdv_to_html(@motif)
-
-          - if @motif.instruction_for_rdv.blank?
-            p.fr-mt-4w
-              i Pas d'instructions à afficher après la prise de rendez-vous
-          - else
-            p.fr-mt-4w Instructions à afficher après la prise de rendez-vous :
-            .fr-highlight.fr-mb-2w
-              i= instruction_for_rdv_to_html(@motif)
+          = render "admin/motifs/restriction_for_rdv_recap", motif: @motif
+          = render "admin/motifs/instruction_for_rdv_recap", motif: @motif
 
     - if current_territory.sectors.any? && @motif.bookable_by_everyone_or_bookable_by_invited_users?
       .card.card-body


### PR DESCRIPTION
# Contexte

On a refait un point avec Mehdi sur ce qu'il reste à faire sur la page de détails de motif et le formulaire de motif pour pouvoir enlever les onglets.
La première étape est de mettre les différentes consigne dans leur propre carte avant les paramètres avancés, et de réordonner ces composants dans le dernier onglet du formulaire, c'est donc ce qu'on fait ici.

# Solution

C'est surtout du changement de l'ordre des parties des vues, pas de changement de comportement de l'appli.