### PR TITLE
Permettre aux organisations RDV Insertion de gérer l'ouverture aux usagers invités depuis le menu de réservation en ligne

### DIFF
--- a/app/controllers/admin/organisations/online_booking/motifs_controller.rb
+++ b/app/controllers/admin/organisations/online_booking/motifs_controller.rb
@@ -47,19 +47,16 @@ class Admin::Organisations::OnlineBooking::MotifsController < AgentAuthControlle
     end
   end
 
-  def open
-    if @motif.update(bookable_by: :everyone)
-      flash[:success] = "Le motif a été ouvert à la réservation en ligne"
-    else
-      flash[:error] = @motif.errors.full_messages
-    end
+  def update_bookable_by
+    if @motif.update(params.permit(:bookable_by))
 
-    redirect_to admin_organisation_online_booking_motif_path(current_organisation, motif_id: @motif.id)
-  end
+      success_messages = {
+        everyone: "Le motif a été ouvert à la réservation en ligne",
+        agents: "Le motif a été fermé à la réservation en ligne",
+        agents_and_prescripteurs_and_invited_users: "La réservation en ligne pour ce motif est maintenant ouverte uniquement aux usagers invités",
+      }
 
-  def close
-    if @motif.update(bookable_by: :agents)
-      flash[:success] = "Le motif a été fermé à la réservation en ligne"
+      flash[:success] = success_messages.fetch(@motif.bookable_by.to_sym)
     else
       flash[:error] = @motif.errors.full_messages
     end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -39,8 +39,7 @@ class Agent::MotifPolicy < ApplicationPolicy
   alias destroy? agent_can_manage_motif?
   alias versions? agent_can_manage_motif?
 
-  alias open? agent_can_manage_motif?
-  alias close? agent_can_manage_motif?
+  alias update_bookable_by? agent_can_manage_motif?
 
   alias current_agent pundit_user
 

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -37,9 +37,14 @@
           - if @motif.bookable_by_agents_and_prescripteurs?
             = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn fr-btn--secondary", method: :post
           - elsif @motif.bookable_by_invited_users?
-            = button_to "Ouvrir à tous les usagers", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
+            .fr-btns-group.fr-btns-group--inline
+              = button_to "Ouvrir à tous les usagers", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
+              = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
           - else
-            = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
+            .fr-btns-group.fr-btns-group--inline
+              = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
+              - if current_organisation.rdv_insertion?
+                = button_to "Ouvrir aux usagers invités", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents_and_prescripteurs_and_invited_users), class: "fr-btn fr-btn--secondary", method: :post
 
     - unless current_organisation.sectorized?
       - if @motif.bookable_by_everyone?
@@ -99,4 +104,7 @@
         .card-body
           h3.fr-h4 Réservation en ligne
           p Ce motif est <b>ouvert</b> à la réservation en ligne : les usagers pourront prendre rendez-vous pour ce motif depuis le lien de réservation (sous réserve d’avoir une plage d’ouverture associée).
-          = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
+          .fr-btns-group.fr-btns-group--inline
+            = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
+            - if current_organisation.rdv_insertion?
+              = button_to "Restreindre aux usagers invités", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents_and_prescripteurs_and_invited_users), class: "fr-btn fr-btn--secondary", method: :post

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -35,11 +35,11 @@
         .card-body
           = render "bookable_by_text", motif: @motif
           - if @motif.bookable_by_agents_and_prescripteurs?
-            = button_to "Ouvrir à la réservation en ligne", open_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary", method: :post
+            = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn fr-btn--secondary", method: :post
           - elsif @motif.bookable_by_invited_users?
-            = button_to "Ouvrir à tous les usagers", open_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn", method: :post
+            = button_to "Ouvrir à tous les usagers", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
           - else
-            = button_to "Ouvrir à la réservation en ligne", open_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn", method: :post
+            = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
 
     - unless current_organisation.sectorized?
       - if @motif.bookable_by_everyone?
@@ -99,4 +99,4 @@
         .card-body
           h3.fr-h4 Réservation en ligne
           p Ce motif est <b>ouvert</b> à la réservation en ligne : les usagers pourront prendre rendez-vous pour ce motif depuis le lien de réservation (sous réserve d’avoir une plage d’ouverture associée).
-          = button_to "Fermer à la réservation en ligne", close_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary", method: :post
+          = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,8 +325,7 @@ Rails.application.routes.draw do
         namespace :online_booking do
           resources :motifs, only: %i[show edit update] do
             member do
-              post :open
-              post :close
+              post :update_bookable_by
               get :edit_user_type
               patch :update_user_type
               get :edit_instructions

--- a/spec/features/agents/online_booking/motif_spec.rb
+++ b/spec/features/agents/online_booking/motif_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Réservation en ligne pour un motif en particulier" do
       expect(page).to have_content("La réservation en ligne pour ce motif est maintenant ouverte uniquement aux usagers invités")
       expect(motif.reload).to have_attributes(bookable_by: "agents_and_prescripteurs_and_invited_users")
 
-      click_on "Ouvrir à la réservation en ligne"
+      click_on "Ouvrir à tous les usagers"
 
       expect(page).to have_content("Le motif a été ouvert à la réservation en ligne")
       expect(motif.reload).to have_attributes(bookable_by: "everyone")

--- a/spec/features/agents/online_booking/motif_spec.rb
+++ b/spec/features/agents/online_booking/motif_spec.rb
@@ -113,4 +113,31 @@ RSpec.describe "Réservation en ligne pour un motif en particulier" do
     expect(page).to have_content("Le motif a été ouvert à la réservation en ligne")
     expect(motif.reload).to have_attributes(bookable_by: "everyone")
   end
+
+  context "quand l'organisation est liée à RDV Insertion" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_insertion) }
+
+    it "permet d'activer ou désactiver l'ouverture aux usagers invités" do
+      visit admin_organisation_online_booking_motif_path(organisation, motif)
+      click_on "Restreindre aux usagers invités"
+
+      expect(page).to have_content("La réservation en ligne pour ce motif est maintenant ouverte uniquement aux usagers invités")
+      expect(motif.reload).to have_attributes(bookable_by: "agents_and_prescripteurs_and_invited_users")
+
+      click_on "Fermer à la réservation en ligne"
+
+      expect(page).to have_content("Le motif a été fermé à la réservation en ligne")
+      expect(motif.reload).to have_attributes(bookable_by: "agents")
+
+      click_on "Ouvrir aux usagers invités"
+
+      expect(page).to have_content("La réservation en ligne pour ce motif est maintenant ouverte uniquement aux usagers invités")
+      expect(motif.reload).to have_attributes(bookable_by: "agents_and_prescripteurs_and_invited_users")
+
+      click_on "Ouvrir à la réservation en ligne"
+
+      expect(page).to have_content("Le motif a été ouvert à la réservation en ligne")
+      expect(motif.reload).to have_attributes(bookable_by: "everyone")
+    end
+  end
 end


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="650" height="388" alt="Screenshot 2026-08-14 at 16 46 10" src="https://github.com/user-attachments/assets/ae322f28-1f1e-4330-9687-ad5fcdf8a416" />|<img width="636" height="306" alt="Screenshot 2026-08-14 at 16 45 52" src="https://github.com/user-attachments/assets/4fb32d77-c7fc-4f89-8834-d722edc5ba1e" />


# Contexte

Pour préparer la suppression de l'onglet "Réservation en ligne" dans le formulaire de motif, il faut qu'on fournisse aux admins de rdv insertion une autre manière de gérer le niveau de réservation spécifique à RDV Insertion qui permet juste aux usagers invités de prendre un rendez-vous.

# Solution

Vu avec Mehdi : on fait au plus simple et on ajoute un bouton pour les organisations RDV Insertion.

