### PR TITLE
Corrige la déclaration de paramètres dans la documentation de visioplainte

### DIFF
--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -67,18 +67,33 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
 
       tags "Rendez-vous"
       description "Crée un rdv et réserve le créneau correspondant."
-      parameter name: "starts_at", in: :query, type: :string,
-                description: "datetime au format iso8601. Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.",
-                example: "2024-08-19T08:00:00+02:00", required: true
+      parameter(name: :params, in: :body,
+                schema: {
+                  type: :object,
+                  properties: {
+                    starts_at: {
+                      type: :string,
+                      description: "datetime au format iso8601. Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.",
+                      example: "2024-08-19T08:00:00+02:00",
+                      required: true,
+                    },
+
+                  },
+                })
 
       response 201, "Prend le rdv" do
         run_test!
         schema rdv_response_schema
-        let(:starts_at) { "2024-08-19T08:00:00+02:00" }
+        let(:params) do
+          { starts_at: "2024-08-19T08:00:00+02:00" }
+        end
       end
 
       response 422, "Si le créneau n'est pas disponible" do
-        let(:starts_at) { "2024-11-19T08:00:00+02:00" }
+        let(:params) do
+          { starts_at: "2024-11-19T08:00:00+02:00" }
+        end
+
         run_test!
         schema type: :object, properties: { errors: { type: :array, items: { type: :string } } }, required: %w[errors]
       end

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
                id: { type: :integer },
                target_url: { type: :string },
                organisation_id: { type: :integer },
-               subscriptions: { type: :array },
+               subscriptions: { type: :array, items: { type: "string" } },
              },
              required: WebhookEndpointBlueprint.reflections[:default].fields.keys,
            })
@@ -59,19 +59,30 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
 
       tags "WebhookEndpoint"
       description "Crée un endpoint de webhook dans l'espace Visioplainte"
-      parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour"
-      parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels"
-      parameter name: "subscriptions[]", in: :query, type: :array, description: <<~DOC
-        Le type de mises à jours pour lesquelles les notifications seront envoyées.
-        Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
-      DOC
+
+      example_values = {
+        target_url: "https://exemple.fr/webhook_rdv_service_public",
+        subscriptions: ["rdv"],
+        secret: "fake_test_secret_123",
+      }
+
+      parameter(name: "webhook_endpoint_attributes", in: :body, description: "Les attributs du webhook endpoint à créer", type: :object, schema: {
+                  example: example_values,
+                  properties: {
+                    target_url: { type: :string, description: "L'url à appeler pour notifier d'une mise à jour" },
+                    secret: { type: :string, description: "Le secret qui servira à signer les appels" },
+                    subscriptions: { type: :array,
+                                     items: { type: "string",
+                                              description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile.", }, }, # rubocop:disable Layout/LineLength
+                  },
+                })
 
       response 201, "Crée l'endpoint de webhook" do
         run_test!
         document_schema
-        let(:target_url) { "https://exemple.fr/webhook_rdv_service_public" }
-        let(:"subscriptions[]") { ["rdv"] } # rubocop:disable RSpec/VariableName
-        let(:secret) { "fake_test_secret_123" }
+        let(:webhook_endpoint_attributes) do
+          example_values
+        end
 
         specify do
           expect(WebhookEndpoint.last).to have_attributes(
@@ -89,7 +100,9 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     patch "Modifier un endpoint de webhook" do
       with_visioplainte_authentication
 
+      tags "WebhookEndpoint"
       description "Crée un endpoint de webhook dans l'espace Visioplainte, typiquement pour faire une rotation de secret"
+
       parameter name: "id", in: :path, type: :integer, description: "L'id de l'endpoint de webhook à modifier"
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour", required: false
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels", required: false
@@ -114,7 +127,10 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
 
     delete "Supprimer un endpoint de webhook" do
       with_visioplainte_authentication
+
+      tags "WebhookEndpoint"
       description "Supprime un endpoint de webhook dans l'espace Visioplainte"
+
       parameter name: "id", in: :path, type: :integer, description: "L'id de l'endpoint de webhook à supprimer"
 
       response 204, "Supprime un endpoint de webhook" do

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
            })
   end
 
+  example_params = {
+    target_url: "https://exemple.fr/webhook_rdv_service_public",
+    subscriptions: ["rdv"],
+    secret: "fake_test_secret_123",
+  }
+
   path "/api/visioplainte/webhook_endpoints" do
     get "Lister les endpoints de webhooks" do
       with_visioplainte_authentication
@@ -60,18 +66,12 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       tags "WebhookEndpoint"
       description "Crée un endpoint de webhook dans l'espace Visioplainte"
 
-      example_values = {
-        target_url: "https://exemple.fr/webhook_rdv_service_public",
-        subscriptions: ["rdv"],
-        secret: "fake_test_secret_123",
-      }
-
       parameter(name: "webhook_endpoint_attributes", in: :body, description: "Les attributs du webhook endpoint à créer", type: :object, schema: {
-                  example: example_values,
+                  example: example_params,
                   properties: {
-                    target_url: { type: :string, description: "L'url à appeler pour notifier d'une mise à jour" },
-                    secret: { type: :string, description: "Le secret qui servira à signer les appels" },
-                    subscriptions: { type: :array,
+                    target_url: { type: :string, required: true, description: "L'url à appeler pour notifier d'une mise à jour" },
+                    secret: { type: :string, required: true, description: "Le secret qui servira à signer les appels" },
+                    subscriptions: { type: :array, required: true,
                                      items: { type: "string",
                                               description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile.", }, }, # rubocop:disable Layout/LineLength
                   },
@@ -80,9 +80,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       response 201, "Crée l'endpoint de webhook" do
         run_test!
         document_schema
-        let(:webhook_endpoint_attributes) do
-          example_values
-        end
+        let(:webhook_endpoint_attributes) { example_params }
 
         specify do
           expect(WebhookEndpoint.last).to have_attributes(
@@ -104,16 +102,25 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       description "Crée un endpoint de webhook dans l'espace Visioplainte, typiquement pour faire une rotation de secret"
 
       parameter name: "id", in: :path, type: :integer, description: "L'id de l'endpoint de webhook à modifier"
-      parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour", required: false
-      parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels", required: false
-      parameter name: "subscriptions[]", in: :query, type: :array, required: false,
-                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées.\
-                Les valeurs possibles à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+
+      parameter(name: "webhook_endpoint_attributes", in: :body, description: "Les attributs du webhook endpoint à créer", type: :object, schema: {
+                  example: example_params,
+                  properties: {
+                    target_url: { type: :string, required: false, description: "L'url à appeler pour notifier d'une mise à jour" },
+                    secret: { type: :string, required: false, description: "Le secret qui servira à signer les appels" },
+                    subscriptions: { type: :array, required: false,
+                                     items: { type: "string",
+                                              description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile.", }, }, # rubocop:disable Layout/LineLength
+                  },
+                })
 
       response 200, "Modifie un endpoint de webhook" do
         run_test!
         document_schema
-        let(:secret) { "new_fake_test_secret_456" }
+        let(:webhook_endpoint_attributes) do
+          { secret: "new_fake_test_secret_456" }
+        end
+
         let(:id) { webhook_endpoint.id }
         let!(:webhook_endpoint) do
           create(:webhook_endpoint, organisation: orga_gendarmerie, target_url: "https://exemple.fr/webhook_rdv_service_public", subscriptions: [:rdv])

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -36,6 +36,7 @@ module ApiSpecMacros
   def with_visioplainte_authentication
     with_examples
     produces "application/json"
+    consumes "application/json"
     stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
     let(:"X-VISIOPLAINTE-API-KEY") do
       "visioplainte-api-test-key-123456"

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -1281,30 +1281,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "target_url",
-            "in": "query",
-            "description": "L'url à appeler pour notifier d'une mise à jour",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "secret",
-            "in": "query",
-            "description": "Le secret qui servira à signer les appels",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "subscriptions[]",
-            "in": "query",
-            "description": "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont [\"rdv\", \"absence\", \"plage_ouverture\", \"user\", \"user_profile\", \"organisation\", \"motif\", \"lieu\", \"agent\", \"agent_role\", \"referent_assignation\"]. Typiquement c'est la valeur rdv qui sera la plus utile.",
-            "schema": {
-              "type": "array"
-            }
           }
         ],
         "tags": [
@@ -1319,8 +1295,8 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 126,
-                      "organisation_id": 163,
+                      "id": 247,
+                      "organisation_id": 634,
                       "subscriptions": [
                         "rdv"
                       ],
@@ -1341,7 +1317,10 @@
                       "type": "integer"
                     },
                     "subscriptions": {
-                      "type": "array"
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -1354,6 +1333,42 @@
               }
             }
           }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "example": {
+                  "target_url": "https://exemple.fr/webhook_rdv_service_public",
+                  "subscriptions": [
+                    "rdv"
+                  ],
+                  "secret": "fake_test_secret_123"
+                },
+                "properties": {
+                  "target_url": {
+                    "type": "string",
+                    "required": true,
+                    "description": "L'url à appeler pour notifier d'une mise à jour"
+                  },
+                  "secret": {
+                    "type": "string",
+                    "required": true,
+                    "description": "Le secret qui servira à signer les appels"
+                  },
+                  "subscriptions": {
+                    "type": "array",
+                    "required": true,
+                    "items": {
+                      "type": "string",
+                      "description": "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont [\"rdv\", \"absence\", \"plage_ouverture\", \"user\", \"user_profile\", \"organisation\", \"motif\", \"lieu\", \"agent\", \"agent_role\", \"referent_assignation\"]. Typiquement c'est la valeur rdv qui sera la plus utile."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": "Les attributs du webhook endpoint à créer"
         }
       }
     },
@@ -1384,34 +1399,10 @@
             "schema": {
               "type": "integer"
             }
-          },
-          {
-            "name": "target_url",
-            "in": "query",
-            "description": "L'url à appeler pour notifier d'une mise à jour",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "secret",
-            "in": "query",
-            "description": "Le secret qui servira à signer les appels",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "subscriptions[]",
-            "in": "query",
-            "required": false,
-            "description": "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont [\"rdv\", \"absence\", \"plage_ouverture\", \"user\", \"user_profile\", \"organisation\", \"motif\", \"lieu\", \"agent\", \"agent_role\", \"referent_assignation\"]. Typiquement c'est la valeur rdv qui sera la plus utile.",
-            "schema": {
-              "type": "array"
-            }
           }
+        ],
+        "tags": [
+          "WebhookEndpoint"
         ],
         "description": "Crée un endpoint de webhook dans l'espace Visioplainte, typiquement pour faire une rotation de secret",
         "responses": {
@@ -1422,8 +1413,8 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 128,
-                      "organisation_id": 165,
+                      "id": 249,
+                      "organisation_id": 636,
                       "subscriptions": [
                         "rdv"
                       ],
@@ -1444,7 +1435,10 @@
                       "type": "integer"
                     },
                     "subscriptions": {
-                      "type": "array"
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -1457,6 +1451,42 @@
               }
             }
           }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "example": {
+                  "target_url": "https://exemple.fr/webhook_rdv_service_public",
+                  "subscriptions": [
+                    "rdv"
+                  ],
+                  "secret": "fake_test_secret_123"
+                },
+                "properties": {
+                  "target_url": {
+                    "type": "string",
+                    "required": false,
+                    "description": "L'url à appeler pour notifier d'une mise à jour"
+                  },
+                  "secret": {
+                    "type": "string",
+                    "required": false,
+                    "description": "Le secret qui servira à signer les appels"
+                  },
+                  "subscriptions": {
+                    "type": "array",
+                    "required": false,
+                    "items": {
+                      "type": "string",
+                      "description": "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont [\"rdv\", \"absence\", \"plage_ouverture\", \"user\", \"user_profile\", \"organisation\", \"motif\", \"lieu\", \"agent\", \"agent_role\", \"referent_assignation\"]. Typiquement c'est la valeur rdv qui sera la plus utile."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": "Les attributs du webhook endpoint à créer"
         }
       },
       "delete": {
@@ -1486,6 +1516,9 @@
               "type": "integer"
             }
           }
+        ],
+        "tags": [
+          "WebhookEndpoint"
         ],
         "description": "Supprime un endpoint de webhook dans l'espace Visioplainte",
         "responses": {

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -944,16 +944,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "starts_at",
-            "in": "query",
-            "description": "datetime au format iso8601. Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.",
-            "example": "2024-08-19T08:00:00+02:00",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "tags": [
@@ -1055,6 +1045,23 @@
                   "required": [
                     "errors"
                   ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "starts_at": {
+                    "type": "string",
+                    "description": "datetime au format iso8601. Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.",
+                    "example": "2024-08-19T08:00:00+02:00",
+                    "required": true
+                  }
                 }
               }
             }


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1437" height="630" alt="Screenshot 2026-08-17 at 14 46 11" src="https://github.com/user-attachments/assets/963fe590-0c6e-4b46-8ebd-663e93706070" />|<img width="1437" height="677" alt="Screenshot 2026-08-17 at 14 45 44" src="https://github.com/user-attachments/assets/286cc22e-e96d-47c1-8890-dbed86e51287" />


L'équipe visioplainte a eu des difficultés avec la création d'endpoint de webhook parce qu'ils envoyaient le paramètre subscriptions en query params et non pas en body de la request.
Et ça se comprend, puisque la doc de l'api indique de les mettre en query params. En regardant plus largement, je me suis rendu compte qu'on fait ça pour tous les params des actions d'écriture dans la doc. 🙀 

Malheureusement, le formalisme pour transformer des query params en params dans la requête est assez différent. Cette PR ne fait donc le fix que sur la doc de visioplainte.
