### PR TITLE
Ajouter un bouton « Nouveau » sur la page de planning

### DIFF
--- a/app/views/admin/planning/_new_modal.html.slim
+++ b/app/views/admin/planning/_new_modal.html.slim
@@ -1,0 +1,41 @@
+/# locals: (agent:)
+
+dialog#planning-new-modal.fr-modal[aria-labelledby="planning-new-modal-title" data-fr-concealing-backdrop="true"]
+  .fr-container.fr-container--fluid.fr-container-md
+    .fr-grid-row.fr-grid-row--center
+      .fr-col-12.fr-col-md-10.fr-col-lg-8
+        .fr-modal__body
+          .fr-modal__header
+            button.fr-btn--close.fr-btn[aria-controls="planning-new-modal" title="Fermer" type="button"]
+              | Fermer
+          .fr-modal__content
+            h2#planning-new-modal-title.fr-modal__title
+              | Que souhaitez-vous créer ?
+
+            .fr-grid-row.fr-grid-row--gutters
+              .fr-col-12.fr-col-md-4
+                .fr-tile.fr-tile--sm.fr-tile--horizontal.fr-enlarge-link
+                  .fr-tile__body
+                    .fr-tile__content
+                      h3.fr-tile__title
+                        = link_to "Un rendez-vous", new_admin_organisation_rdv_wizard_step_path(current_organisation, agent_ids: [agent.id])
+                      p.fr-tile__desc
+                        | Prendre un rendez-vous pour un usager
+
+              .fr-col-12.fr-col-md-4
+                .fr-tile.fr-tile--sm.fr-tile--horizontal.fr-enlarge-link
+                  .fr-tile__body
+                    .fr-tile__content
+                      h3.fr-tile__title
+                        = link_to "Une plage d’ouverture", new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: agent.id)
+                      p.fr-tile__desc
+                        | Ouvrir des créneaux de disponibilité
+
+              .fr-col-12.fr-col-md-4
+                .fr-tile.fr-tile--sm.fr-tile--horizontal.fr-enlarge-link
+                  .fr-tile__body
+                    .fr-tile__content
+                      h3.fr-tile__title
+                        = link_to "Une indisponibilité", new_admin_organisation_planning_absence_path(current_organisation, agent_id: agent.id)
+                      p.fr-tile__desc
+                        | Bloquer une période (congé, absence…)

--- a/app/views/admin/planning/_new_modal.html.slim
+++ b/app/views/admin/planning/_new_modal.html.slim
@@ -12,8 +12,8 @@ dialog#planning-new-modal.fr-modal[aria-labelledby="planning-new-modal-title" da
             h2#planning-new-modal-title.fr-modal__title
               | Que souhaitez-vous créer ?
 
-            .fr-grid-row.fr-grid-row--gutters
-              .fr-col-12.fr-col-md-4
+            ul.fr-raw-list.fr-grid-row.fr-grid-row--gutters
+              li.fr-col-12.fr-col-md-4
                 .fr-tile.fr-tile--sm.fr-tile--horizontal.fr-enlarge-link
                   .fr-tile__body
                     .fr-tile__content
@@ -22,7 +22,7 @@ dialog#planning-new-modal.fr-modal[aria-labelledby="planning-new-modal-title" da
                       p.fr-tile__desc
                         | Prendre un rendez-vous pour un usager
 
-              .fr-col-12.fr-col-md-4
+              li.fr-col-12.fr-col-md-4
                 .fr-tile.fr-tile--sm.fr-tile--horizontal.fr-enlarge-link
                   .fr-tile__body
                     .fr-tile__content
@@ -31,7 +31,7 @@ dialog#planning-new-modal.fr-modal[aria-labelledby="planning-new-modal-title" da
                       p.fr-tile__desc
                         | Ouvrir des créneaux de disponibilité
 
-              .fr-col-12.fr-col-md-4
+              li.fr-col-12.fr-col-md-4
                 .fr-tile.fr-tile--sm.fr-tile--horizontal.fr-enlarge-link
                   .fr-tile__body
                     .fr-tile__content

--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -6,6 +6,12 @@
   - else
     | Agenda de #{@agent.full_name_and_service}
 
+- content_for :right_of_page_title do
+  button.fr-btn.fr-icon-add-line.fr-btn--icon-left[data-fr-opened="false" aria-controls="planning-new-modal" type="button"]
+    | Nouveau
+
+= render partial: "admin/planning/new_modal", locals: { agent: @agent }
+
 ruby:
   event_sources = [
     { id: "Rdv",            url: admin_api_agenda_rdvs_path(agent_id: @agent.id, organisation_id: current_organisation.id, format: :json) },

--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -7,7 +7,7 @@
     | Agenda de #{@agent.full_name_and_service}
 
 - content_for :right_of_page_title do
-  button.fr-btn.fr-icon-add-line.fr-btn--icon-left[data-fr-opened="false" aria-controls="planning-new-modal" type="button"]
+  button.fr-btn.fr-btn--secondary.fr-icon-add-line.fr-btn--icon-left[data-fr-opened="false" aria-controls="planning-new-modal" type="button"]
     | Nouveau
 
 = render partial: "admin/planning/new_modal", locals: { agent: @agent }


### PR DESCRIPTION
# Contexte

Nous n’avons actuellement pas de solution accessible pour créer un nouveau RDV. La technique est de cliquer sur le calendrier pour créer un nouveau RDV.

# Solution

Je propose donc de rajouter un bouton « Nouveau » qui permet d’accéder à la création de RDV, de plage d’ouverture et d’indisponibilité.
On aurait pu faire seulement une redirection vers le nouveau RDV, mais nous avons eu à plusieurs reprises des discussions sur deux sujets :
- Faire en sorte qu’au clic sur le planning on puisse créer une plage d’ouverture et une indisponibilité
- Faire en sorte d’un jour supprimer la vue agenda pour les plages d’ouvertures et utiliser la vue « planning ».

## Captures d'écran

<img width="911" height="467" alt="image" src="https://github.com/user-attachments/assets/98c01b3e-8c10-4603-85bc-507c317015ec" />
<img width="797" height="440" alt="image" src="https://github.com/user-attachments/assets/07a91ced-97fc-4e5a-b5b7-94c1b9e73bab" />

