### PR TITLE
Amélioration de l’accessibilité des liens avec icon uniquement

### DIFF
--- a/app/helpers/dsfr_helper.rb
+++ b/app/helpers/dsfr_helper.rb
@@ -7,6 +7,13 @@ module DsfrHelper
     end
   end
 
+  # Lien n'affichant qu'une icône DSFR (fr-icon-*) : le nom accessible ne doit pas reposer
+  # uniquement sur l'attribut title (RGAA 6.1/6.2), on ajoute donc un texte fr-sr-only.
+  def icon_link_to(accessible_name, url, html_options = {})
+    html_options = html_options.reverse_merge(title: accessible_name)
+    link_to(url, html_options) { tag.span(accessible_name, class: "fr-sr-only") }
+  end
+
   def icon(icon_name, html_options = {})
     if html_options[:title]
       tag.span("", class: "#{icon_name} #{html_options.delete(:class)}", **html_options)

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -33,20 +33,17 @@ tr id="agent_#{agent.id}"
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
       - if agent_policy.create? && !agent.invitation_accepted? && !agent.is_an_intervenant?
-        = link_to "",
+        = icon_link_to "Renvoyer l’invitation",
                 reinvite_admin_organisation_invitation_path(current_organisation, agent),
                 method: :post,
-                class: "fr-btn fr-btn--tertiary fr-icon-send-plane-fill",
-                title: "Renvoyer l’invitation"
+                class: "fr-btn fr-btn--tertiary fr-icon-send-plane-fill"
       - if agent_policy.edit?
-        = link_to "", edit_admin_organisation_agent_path(current_organisation, agent),
-                title: t("helpers.edit"),
+        = icon_link_to t("helpers.edit"), edit_admin_organisation_agent_path(current_organisation, agent),
                 class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
       - if agent_policy.destroy?
         - agent_removal_presenter = AgentRemovalPresenter.new(agent, current_organisation)
         - path = admin_organisation_agent_path(current_organisation, agent)
-        = link_to "", path,
+        = icon_link_to agent_removal_presenter.button_value, path,
                 method: :delete,
-                title: agent_removal_presenter.button_value,
                 data: { confirm: agent_removal_presenter.confirm_message },
                 class: "fr-btn fr-btn--tertiary fr-icon-delete-bin-fill"

--- a/app/views/admin/lieux/_lieu.html.slim
+++ b/app/views/admin/lieux/_lieu.html.slim
@@ -13,6 +13,5 @@ tr id="lieu_#{lieu.id}"
   td= link_to nb_rdv > 0 ? nb_rdv : "aucun", admin_organisation_rdvs_path(current_organisation, lieu_id: lieu.id, start: Time.zone.now.beginning_of_day, end: Time.zone.now.end_of_day )
   td
     - if @lieux_policy.edit?
-      div.mr-3= link_to "", edit_admin_organisation_lieu_path(current_organisation, lieu),
-              title: t("helpers.edit"),
+      div.mr-3= icon_link_to t("helpers.edit"), edit_admin_organisation_lieu_path(current_organisation, lieu),
               class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-edit-fill"

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -31,32 +31,29 @@ tr
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
       - if @current_tab != :archived
         - if motif_policy.edit?
-          = link_to "", edit_admin_organisation_motif_path(current_organisation, motif),
-                  class: "fr-btn fr-btn--tertiary fr-icon-edit-fill",
-                  title: t("admin.motifs.actions.edit")
+          = icon_link_to t("admin.motifs.actions.edit"), edit_admin_organisation_motif_path(current_organisation, motif),
+                  class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
         - if motif_policy.duplicate?
-          = link_to "", new_admin_organisation_motif_path(current_organisation, duplicated_from_motif_id: motif.id),
-                  class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill",
-                  title: t("admin.motifs.actions.duplicate")
+          = icon_link_to t("admin.motifs.actions.duplicate"), new_admin_organisation_motif_path(current_organisation, duplicated_from_motif_id: motif.id),
+                  class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill"
 
       - if motif.archived?
         - if motif_policy.unarchive?
-          = link_to "", unarchive_admin_organisation_motif_path(current_organisation, motif),
+          = icon_link_to t("admin.motifs.actions.unarchive"), unarchive_admin_organisation_motif_path(current_organisation, motif),
                   class: "fr-btn fr-btn--tertiary fr-icon-upload-fill",
-                  method: :post,
-                  title: t("admin.motifs.actions.unarchive")
+                  method: :post
         - if motif_policy.destroy?
           - if motif.destroyable?
-            = link_to "", admin_organisation_motif_path(current_organisation, motif),
+            = icon_link_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(current_organisation, motif),
                     class: "fr-btn fr-btn--tertiary fr-icon-delete-fill",
                     method: :delete,
-                    title: t("admin.motifs.actions.destroy"), data: { confirm: t("admin.motifs.actions.destroy_confirm") }
+                    data: { confirm: t("admin.motifs.actions.destroy_confirm") }
           - else
             button.fr-btn.fr-btn--tertiary.fr-icon-delete-fill [disabled="disabled" title=t("admin.motifs.actions.not_destroyable_explanation")]
+              span.fr-sr-only= t("admin.motifs.actions.not_destroyable_explanation")
       - else
         - if motif_policy.archive?
-          = link_to "", archive_admin_organisation_motif_path(current_organisation, motif),
+          = icon_link_to t("admin.motifs.actions.archive"), archive_admin_organisation_motif_path(current_organisation, motif),
                   class: "fr-btn fr-btn--tertiary fr-icon-archive-fill",
                   method: :post,
-                  title: t("admin.motifs.actions.archive"),
                   data: { confirm: t("admin.motifs.actions.archive_confirm") }

--- a/app/views/admin/planning/absences/_absence.html.slim
+++ b/app/views/admin/planning/absences/_absence.html.slim
@@ -13,14 +13,11 @@ tr
 
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.rdv-gap-05rem
-      = link_to "",  edit_admin_organisation_planning_absence_path(current_organisation, absence),
-              title: t("helpers.edit"),
+      = icon_link_to t("helpers.edit"), edit_admin_organisation_planning_absence_path(current_organisation, absence),
               class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
-      = link_to "", new_admin_organisation_planning_absence_path(current_organisation, agent_id: absence.agent, duplicate_absence_id: absence),
-              title: t("helpers.clone"),
+      = icon_link_to t("helpers.clone"), new_admin_organisation_planning_absence_path(current_organisation, agent_id: absence.agent, duplicate_absence_id: absence),
               class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill"
-      = link_to "", admin_organisation_planning_absence_path(current_organisation, absence),
+      = icon_link_to t("helpers.delete"), admin_organisation_planning_absence_path(current_organisation, absence),
               method: :delete,
-              title: t("helpers.delete"),
               data: { confirm: t(".confirm_delete_absence")},
               class: "fr-btn fr-btn--tertiary fr-icon-delete-bin-fill"

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -32,14 +32,11 @@ tr
         | )
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
-      = link_to "", edit_admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),
-              title: "Modifier",
+      = icon_link_to "Modifier", edit_admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),
               class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
-      = link_to "", new_admin_organisation_planning_plage_ouverture_path(organisation, agent_id: plage_ouverture.agent, duplicate_plage_ouverture_id: plage_ouverture),
-              title: "Dupliquer",
+      = icon_link_to "Dupliquer", new_admin_organisation_planning_plage_ouverture_path(organisation, agent_id: plage_ouverture.agent, duplicate_plage_ouverture_id: plage_ouverture),
               class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill"
-      = link_to "", admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),
+      = icon_link_to "Supprimer", admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),
               method: :delete,
-              title: "Supprimer",
               class: "fr-btn fr-btn--tertiary fr-icon-delete-fill",
               data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?" }

--- a/app/views/admin/rdv_wizard_steps/_participation_form.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_participation_form.html.slim
@@ -19,6 +19,7 @@ div id=element_id
         ), \
         data: { modal: "true" }, title: t("helpers.edit") do
         = icon("fr-icon-edit-line", class: "fr-icon--sm")
+        span.fr-sr-only= t("helpers.edit")
   .ml-3
     = render "admin/users/notifications_preferences", user: user.user_to_notify
     - if participation.user.user_to_notify.valid_email? || participation.user.user_to_notify.phone_number.present?

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -28,6 +28,7 @@ ruby:
             remove_user_path = new_admin_organisation_rdv_wizard_step_path(remove_path_params)
           div.ml-2= link_to remove_user_path, title: t("helpers.remove")
             = icon("fr-icon-delete-line", class: "fr-icon--sm")
+            span.fr-sr-only= t("helpers.remove")
           / la ligne suivante gère le cas d’un usager qui ne fait pas partie de l’orga courante mais d’une autre orga dans laquelle l’agent courant a les droits suffisants pour l’éditer
           - organisation_where_editable = current_agent.organisations.to_a.prepend(current_organisation).uniq.find { |org| Agent::UserPolicy.new(AgentOrganisationContext.new(current_agent, org), user).edit? }
           - if organisation_where_editable
@@ -37,6 +38,7 @@ ruby:
                 ), \
                 data: { modal: "true" }, title: t("helpers.edit") do
                 = icon("fr-icon-edit-line", class: "fr-icon--sm")
+                span.fr-sr-only= t("helpers.edit")
 
     - show_add_user = @rdv.users.empty?
     .collapse.collapse-add-user-selection.no-transition class=(show_add_user ? "" : "show")

--- a/app/views/admin/territories/agents/index.html.slim
+++ b/app/views/admin/territories/agents/index.html.slim
@@ -27,8 +27,7 @@
 
             td
               .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
-                = link_to "", edit_admin_territory_agent_path(current_territory, agent),
-                        title: t(".edit_agents"),
+                = icon_link_to t(".edit_agents"), edit_admin_territory_agent_path(current_territory, agent),
                         class: "fr-btn fr-btn--tertiary fr-icon-edit-line"
     .d-flex.justify-content-center
       = paginate @agents, theme: "dsfr"

--- a/app/views/admin/territories/motifs/_motifs_table.html.slim
+++ b/app/views/admin/territories/motifs/_motifs_table.html.slim
@@ -53,28 +53,26 @@ table.table.table-centered.table-bordered.table-sm.mb-0[class=(display_checkboxe
           td.p-0
             .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.fr-mt-4v.fr-ml-2v
               - if @current_tab != :archived
-                = link_to "", edit_admin_organisation_motif_path(motif.organisation, motif),
+                = icon_link_to "Modifier - Ouvre une ouvelle fenêtre", edit_admin_organisation_motif_path(motif.organisation, motif),
                         class: "fr-btn fr-btn--tertiary fr-icon-edit-fill",
-                        title: "Modifier - Ouvre une ouvelle fenêtre",
                         target: :_blank
               - if motif.archived?
                 - if motif_policy.unarchive?
-                  = link_to "", unarchive_admin_territory_motif_path(current_territory, motif),
+                  = icon_link_to "Réactiver", unarchive_admin_territory_motif_path(current_territory, motif),
                           class: "fr-btn fr-btn--tertiary fr-icon-upload-fill",
-                          method: :post,
-                          title: "Réactiver"
+                          method: :post
                 - if motif_policy.destroy?
                   - if motif.destroyable?
-                    = link_to "", admin_territory_motif_path(current_territory, motif),
+                    = icon_link_to "Supprimer", admin_territory_motif_path(current_territory, motif),
                             class: "fr-btn fr-btn--tertiary fr-icon-delete-fill",
                             method: :delete,
-                            title: "Supprimer", data: { confirm: "Confirmez-vous la suppression de ce motif ?" }
+                            data: { confirm: "Confirmez-vous la suppression de ce motif ?" }
                   - else
                     button.fr-btn.fr-btn--tertiary.fr-icon-delete-line [disabled="disabled" title=t("admin.motifs.actions.not_destroyable_explanation")]
+                      span.fr-sr-only= t("admin.motifs.actions.not_destroyable_explanation")
               - else
                 - if motif_policy.archive?
-                  = link_to "", archive_admin_territory_motif_path(current_territory, motif),
+                  = icon_link_to "Archiver", archive_admin_territory_motif_path(current_territory, motif),
                           class: "fr-btn fr-btn--tertiary fr-icon-archive-fill",
                           method: :post,
-                          title: "Archiver",
                           data: { confirm: t("admin.motifs.actions.archive_confirm") }

--- a/app/views/admin/territories/sectors/index.html.slim
+++ b/app/views/admin/territories/sectors/index.html.slim
@@ -53,13 +53,11 @@
                 .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
                   - policy = Agent::SectorPolicy.new(current_agent, sector)
                   - if policy.show?
-                    = link_to "", admin_territory_sector_path(current_territory, sector),
-                            title: "Modifier",
+                    = icon_link_to "Modifier", admin_territory_sector_path(current_territory, sector),
                             class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
                   - if policy.destroy?
-                    = link_to "", admin_territory_sector_path(current_territory, sector),
+                    = icon_link_to "Supprimer", admin_territory_sector_path(current_territory, sector),
                             method: :delete,
-                            title: "Supprimer",
                             class: "fr-btn fr-btn--tertiary fr-icon-delete-fill"
       .pb-3.pr-3.pl-3
         div= paginate @sectors, theme: "dsfr"

--- a/app/views/admin/territories/teams/index.html.slim
+++ b/app/views/admin/territories/teams/index.html.slim
@@ -22,12 +22,10 @@
           td = team.agents.count
           td
             .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
-              = link_to "", edit_admin_territory_team_path(current_territory, team),
-                      title: "Modifier",
+              = icon_link_to "Modifier", edit_admin_territory_team_path(current_territory, team),
                       class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
-              = link_to "", admin_territory_team_path(current_territory, team),
+              = icon_link_to t("helpers.delete"), admin_territory_team_path(current_territory, team),
                       method: :delete,
-                      title: t("helpers.delete"),
                       data: { confirm: "Confirmez-vous la suppression de cette équipe ?"},
                       class: "fr-btn fr-btn--tertiary fr-icon-delete-fill"
   .d-flex.justify-content-center

--- a/app/views/admin/territories/webhook_endpoints/index.html.slim
+++ b/app/views/admin/territories/webhook_endpoints/index.html.slim
@@ -26,11 +26,10 @@
                   td = webhook.target_url
                   td
                     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
-                      = link_to "", edit_admin_territory_webhook_endpoint_path(current_territory, webhook),
-                              title: "Modifier",
+                      = icon_link_to "Modifier", edit_admin_territory_webhook_endpoint_path(current_territory, webhook),
                               class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
-                      = link_to "", admin_territory_webhook_endpoint_path(current_territory, webhook),
-                              title: "Supprimer", method: :delete, data: { confirm: "Voulez-vous vraiment supprimer ce endpoint ?" },
+                      = icon_link_to "Supprimer", admin_territory_webhook_endpoint_path(current_territory, webhook),
+                              method: :delete, data: { confirm: "Voulez-vous vraiment supprimer ce endpoint ?" },
                               class: "fr-btn fr-btn--tertiary fr-icon-delete-fill"
 
         .d-flex.flex-gap-1em


### PR DESCRIPTION
Fait suite à l'audit RGAA de l'espace agent commencée par @Teodora-Stanki 

# Contexte

L’audit RGAA de l'espace agent a relevé plusieurs non-conformités sur les critères **6.1** et **6.2**, sur les écrans Accueil/organisations, Planning (plages d'ouverture), et les étapes 2, 3 et 4 du parcours de prise de RDV.

- **Critère 6.1** — *« Chaque lien est-il explicite (hors cas particuliers) ? »* : un lien est explicite quand sa fonction et sa destination sont compréhensibles à partir de son seul intitulé, ou de son contexte immédiat (phrase, cellule de tableau, titre précédent...).
- **Critère 6.2** — *« Chaque lien a-t-il un intitulé ? »* : chaque lien doit porter un intitulé accessible aux technologies d'assistance.

En pratique, tous les boutons d'action à icône seule (Modifier, Dupliquer, Supprimer, Archiver...) de l'espace agent étaient construits ainsi :

```slim
= link_to "", edit_admin_organisation_motif_path(...),
        class: "fr-btn fr-btn--tertiary fr-icon-edit-fill",
        title: "Modifier"
```

Le texte du lien est vide, et l'icône DSFR (`fr-icon-*`) est une image de fond CSS, invisible pour les technologies d'assistance. Le seul porteur du nom accessible est donc l'attribut `title`, or ce n'est pas une technique fiable : `title` n'est pas exposé par défaut par tous les lecteurs d'écran ni sur tous les supports (mobile notamment), ce qui rend l'action inintelligible pour une partie des utilisateurs et utilisatrices de technologies d'assistance. C'est ce qui a fait échouer les critères 6.1/6.2 sur les écrans audités.

Voir : https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/title#accessibility_concerns

Ce pattern étant dupliqué à l'identique dans une dizaine de fichiers, la même non-conformité était présente sur d'autres écrans non couverts par cet audit (gestion des territoires : agents, motifs, secteurs, équipes, webhooks) : ils sont corrigés dans la même PR par cohérence.

# Solution

Ajout d'un helper `icon_link_to(accessible_name, url, html_options)` dans `DsfrHelper`, qui construit le lien à icône seule en ajoutant un texte masqué visuellement mais lu par les lecteurs d'écran (classe DSFR `fr-sr-only`), en plus du `title` conservé comme infobulle :

```ruby
def icon_link_to(accessible_name, url, html_options = {})
  html_options = html_options.reverse_merge(title: accessible_name)
  link_to(url, html_options) { tag.span(accessible_name, class: "fr-sr-only") }
end
```