### PR TITLE
Forwarder les emails aux admins ayant créé les intervenant en cas de réponse des usagers

### DIFF
--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -28,12 +28,23 @@ class TransferEmailReplyJob < ApplicationJob
   def perform(sendinblue_hash)
     @sendinblue_hash = sendinblue_hash.with_indifferent_access
 
-    if rdv&.agents&.pluck(:email)&.compact&.any?
+    if rdv.blank?
+      forward_to_default_mailbox
+      return
+    end
+
+    if rdv.agents.pluck(:email).compact.any?
       notify_agents
     elsif rdv&.organisation&.email.present?
-      notify_organisation
+      notify_organisation(rdv.organisation.email)
     else
-      forward_to_default_mailbox
+      inviters_of_intervenants = rdv.agents.map(&:invited_by)
+
+      if inviters_of_intervenants.any?
+        notify_organisation(inviters_of_intervenants.first.email)
+      else
+        forward_to_default_mailbox
+      end
     end
   end
 
@@ -49,11 +60,11 @@ class TransferEmailReplyJob < ApplicationJob
     ).deliver_now
   end
 
-  def notify_organisation
+  def notify_organisation(email_address)
     Agents::ReplyTransferMailer.notify_organisation(
       rdv: rdv,
       author: user || source_mail.header[:from],
-      organisation: rdv.organisation,
+      email_address: email_address,
       reply_body: extracted_response,
       source_mail: source_mail
     ).deliver_now

--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -19,9 +19,9 @@ class Agents::ReplyTransferMailer < ApplicationMailer
 
   # @param [Rdv] rdv
   # @param [User, String] author
-  # @param [Organisation] organisation
+  # @param [String] email_address
   # @param [Mail::Message] source_mail
-  def notify_organisation(rdv:, author:, organisation:, reply_body:, source_mail:)
+  def notify_organisation(rdv:, author:, email_address:, reply_body:, source_mail:)
     @rdv = rdv
     @author = author
     @reply_subject = source_mail.subject
@@ -29,7 +29,7 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     @attachment_names = source_mail.attachments.map(&:filename).join(", ")
     @date = relative_date_with_preposition(@rdv.starts_at)
 
-    mail(to: organisation.email, subject: "Message d'usager⋅e au sujet d’un RDV #{@date}")
+    mail(to: email_address, subject: "Message d'usager⋅e au sujet d’un RDV #{@date}")
   end
 
   # @param [String] reply_body

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -160,12 +160,14 @@ RSpec.describe TransferEmailReplyJob do
 
       context "et que l'organisation n'a pas d'adresse email" do
         let!(:organisation) { create(:organisation, email: nil) }
+        let!(:agent) { create(:agent, :intervenant, first_name: "Jeanne", last_name: "Intervenante", invited_by: admin) }
+        let(:admin) { create(:agent, admin_role_in_organisations: [organisation]) }
 
-        it "transfère le mail à notre support" do
+        it "transfère le mail à l'agent qui a créé l'intervenant" do
           expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
           transferred_email = ActionMailer::Base.deliveries.last
-          expect(transferred_email.to).to eq(["support@rdv-service-public.fr"])
-          expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+          expect(transferred_email.to).to eq([admin.email])
+          expect(transferred_email.html_part.body.to_s).to include(%(Dans le cadre du RDV du 20 mai avec J. INTERVENANTE, l'usager⋅e Bénédicte FICIAIRE a envoyé))
         end
       end
     end

--- a/spec/mailers/previews/agents/reply_transfer_mailer_preview.rb
+++ b/spec/mailers/previews/agents/reply_transfer_mailer_preview.rb
@@ -27,4 +27,33 @@ class Agents::ReplyTransferMailerPreview < ActionMailer::Preview
       source_mail: source_mail
     )
   end
+
+  def notify_organisation
+    rdv = Rdv.last
+
+    source_mail = Mail.new do
+      subject "Re: RDV confirmé le #{I18n.l(rdv.starts_at, format: :human)}"
+
+      text_part do
+        body "Bonjour,\nVoici une phrase après un saut de ligne."
+      end
+
+      attachments["signature.svg"] = { mime_type: "image/svg+xml", content: "" }
+    end
+
+    body = <<~MARKDOWN
+      Bonjour,
+      Voici une phrase après un saut de ligne.
+
+      Voici une autre phrase après deux sauts de ligne (saut de paragraphe)
+    MARKDOWN
+
+    Agents::ReplyTransferMailer.notify_organisation(
+      rdv: rdv,
+      author: rdv.users.first,
+      organisation: rdv.organisation,
+      reply_body: body,
+      source_mail: source_mail
+    )
+  end
 end


### PR DESCRIPTION
On a eu un ticket zammad pour une réponse d'un usager à un mail de rappel pour un rendez-vous avec un intervenant.

Plutôt que de faire passer le mail par chez nous, on peut l'envoyer à l'agent qui a créé le compte de l'intervenant, en réutilisant le template utilisé pour renvoyer le mail à l'organisation.