### PR TITLE
Détection des serveurs CalDAV qui ne supportent pas les sync token

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -82,9 +82,14 @@ class Agents::CaldavSyncController < AgentAuthController
     end
 
     begin
-      client.calendars.find(agenda_url)
+      calendar = client.calendars.find(agenda_url, sync: true)
     rescue StandardError
       return "L’accès en lecture au calendrier a échoué. Veuillez vérifier l’URL de l’agenda."
+    end
+
+    if calendar.sync_token.blank?
+      return "Votre serveur CalDAV ne supporte pas la synchronisation incrémentale (sync-token), requise pour connecter " \
+             "votre agenda à RDV Service Public. Veuillez contacter votre fournisseur d’agenda ou utiliser un autre serveur CalDAV."
     end
 
     begin

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Agents::CaldavSyncController, type: :controller do
 
       it "ne sauvegarde pas les identifiants" do
         put :update, params: caldav_params
-        expect(agent.reload.caldav_username).to be_nil
+        expect(agent.caldav_config).to be_nil
       end
     end
 

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Agents::CaldavSyncController, type: :controller do
     allow(caldav_client).to receive(:principal_url).and_return("https://caldav.example.fr/dav/principals/user")
     allow(caldav_client).to receive(:events).and_return(caldav_events)
     allow(caldav_client).to receive(:calendars).and_return(caldav_calendars)
-    allow(caldav_calendars).to receive(:find).and_return(double)
+    allow(caldav_calendars).to receive(:find).and_return(instance_double(Calendav::Calendar, sync_token: "some-sync-token"))
     allow(caldav_events).to receive(:create).and_return(instance_double(Calendav::Event, url: "https://caldav.example.fr/dav/calendars/user/default/test.ics"))
     allow(caldav_events).to receive(:delete)
   end
@@ -84,6 +84,27 @@ RSpec.describe Agents::CaldavSyncController, type: :controller do
       it "ne sauvegarde pas les identifiants" do
         put :update, params: caldav_params
         expect(agent.caldav_config).to be_nil
+      end
+    end
+
+    context "quand le serveur CalDAV ne supporte pas la synchronisation incrémentale (sync-token)" do
+      before do
+        allow(caldav_calendars).to receive(:find).and_return(instance_double(Calendav::Calendar, sync_token: nil))
+      end
+
+      it "affiche un message d’erreur dédié" do
+        put :update, params: caldav_params
+
+        expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
+        expect(flash[:alert]).to eq(
+          "Votre serveur CalDAV ne supporte pas la synchronisation incrémentale (sync-token), requise pour connecter " \
+          "votre agenda à RDV Service Public. Veuillez contacter votre fournisseur d’agenda ou utiliser un autre serveur CalDAV."
+        )
+      end
+
+      it "ne sauvegarde pas les identifiants" do
+        put :update, params: caldav_params
+        expect(agent.reload.caldav_username).to be_nil
       end
     end
 


### PR DESCRIPTION
# Contexte

Certains serveurs CalDAV ne supportent pas le mécanisme de synchronisation incrémentale (sync-token, RFC 6578). Pour ces serveurs, chaque cycle d'import automatique des absences (toutes les 15 minutes) déclenche un fetch complet et non borné de tout l'historique du calendrier, ce qui peut être long et lourd, aussi bien pour notre serveur que pour celui de l'agent.

# Solution

On détecte le support du sync-token dès la configuration de la connexion CalDAV par l'agent, plutôt que de laisser l'import automatique échouer silencieusement ou tourner en boucle sur un fetch complet à chaque exécution.

L'étape de vérification "lecture du calendrier" (`Agents::CaldavSyncController#caldav_config_error`) demande désormais le `sync_token` lors de son appel à l'agenda (`client.calendars.find(agenda_url, sync: true)`). Si le serveur ne renvoie aucun `sync_token`, la connexion est refusée avec un message explicite invitant l'agent à contacter son fournisseur d'agenda ou à utiliser un autre serveur CalDAV.

Comme la connexion n'est jamais enregistrée dans ce cas, l'agent ne se retrouve jamais avec une configuration CalDAV incomplète qui déclencherait des imports automatiques inefficaces.
