### PR TITLE
Corrige un crash sur la page de config CalDAV

### DIFF
--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -25,7 +25,7 @@ p
   = external_link_to("contacter le support", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation CalDAV"))
   | .
 
-- if current_agent.caldav_config.caldav_disconnect_started_at.present?
+- if current_agent.caldav_config&.caldav_disconnect_started_at.present?
     p
       |> Les événements qui avaient été importés dans votre agenda sont en cours de suppression. Cela peut prendre quelques minutes.
       | Vous pouvez revenir sur cette page plus tard pour reconfigurer vos identifiants CalDAV.

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Agents::CaldavSyncController, type: :controller do
+  render_views
+
   let(:agent) { create(:agent) }
   let(:caldav_client) { instance_double(Calendav::Client) }
   let(:caldav_events) { instance_double(Calendav::Clients::EventsClient) }


### PR DESCRIPTION
Corrige une erreur faite dans #6612 qui fait crasher la page de config CalDAV si l'agent n'a pas de config (donc dans la plupart des cas).

Premier commit : red spec (en ajoutant `render_views`)
Second commit : le fix