### PR TITLE
Correction de l’affichage de la recherche de RDV collectif

### DIFF
--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -75,6 +75,26 @@
   @include dsfr-input-style;
 }
 
+// Height override
+// Le thème select2-bootstrap4 vendored (dist) fige la hauteur du champ à la valeur par défaut de
+// Bootstrap (2.25rem), ce qui la rend plus basse que les champs fr-input du DSFR à côté desquels
+// il apparaît désormais (ex: le champ date du même formulaire, dont la hauteur DSFR est fixée à
+// 2.5rem via .fr-input:not(textarea){max-height:2.5rem}). On réaligne donc sur cette même
+// hauteur, et on centre le texte verticalement en flex puisque le contenu ne s'étire pas
+// automatiquement pour occuper la nouvelle hauteur.
+.select2-container--bootstrap4 .select2-selection--single {
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  .select2-selection__rendered {
+    flex: 1;
+    min-width: 0;
+    padding-right: 1.25rem;
+  }
+}
+
 .select2-container--bootstrap4 .select2-selection.form-control {
   @include dsfr-input-style;
 }

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -10,23 +10,28 @@
 .card
   - unless needs_collectif_motif
     .card-header
-      = simple_form_for(@form, as: "", url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :get) do |f|
-        .row
-          .col-md-4
-            = date_input(f, :from_date, label = "À partir du", value: @form.from_date)
-          .col-md-4
-            = f.input :motif_id, \
-              include_blank: true, \
-              collection: @motifs, \
-              as: :select, \
-              label_method: -> { motif_name_and_location_type(_1) }, \
-              input_html: { \
-                data: { placeholder: "Sélectionnez un motif", "allow-clear": true }, \
-                class: "select2-input", \
-              }
-          .col-md-3.mt-4
-            = f.input :with_remaining_seats, as: :boolean, label: "Avec des places disponibles"
-          .col-md-1.d-flex-justify-content-end.mt-3
+      = form_for(@form, as: "", url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :get, builder: Dsfr::FormBuilder) do |f|
+        .fr-grid-row.fr-grid-row--gutters.fr-grid-row--bottom
+          .fr-col-12.fr-col-md-3
+            = f.dsfr_text_field :from_date, \
+              label: "À partir du", \
+              value: @form.from_date.strftime("%d/%m/%Y"), \
+              data: { behaviour: "datepicker" }, \
+              autocomplete: "off", \
+              placeholder: "__/__/___"
+          .fr-col-12.fr-col-md-3
+            .fr-select-group
+              = f.label :motif_id, "Motif", class: "fr-label"
+              = f.select :motif_id, \
+                @motifs.map { |motif| [motif_name_and_location_type(motif), motif.id] }, \
+                { include_blank: true }, \
+                class: "fr-select select2-input", \
+                data: { placeholder: "Sélectionnez un motif", "allow-clear": true }
+          .fr-col-12.fr-col-md-4
+            .fr-checkbox-group
+              = f.check_box :with_remaining_seats
+              = f.label :with_remaining_seats, "Avec des places disponibles", class: "fr-label"
+          .fr-col-12.fr-col-md-2.fr-btns-group--right
             = f.submit "Filtrer", class: "fr-btn fr-btn--secondary"
 
   .card-body


### PR DESCRIPTION
# Contexte

Ça fait un moment que je constate que les alignements des champs dans le show de RDV collectifs ne sont pas corrects.

# Solution

J’en profite donc pour :
- Corriger les alignements
- Corriger la hauteur du select2 de selection de motif 
- Passage au DSFR de la checkbox

C’est loin d’être parfait, et il faudra peut-être un jour revoir cette page mais en attendant ça fait un peu plus propre.

## Captures d'écran

Avant | Après
:- | -:
<img width="1498" height="460" alt="image" src="https://github.com/user-attachments/assets/26adfbc2-067d-4c53-9e0b-7e452d0ad950" /> | <img width="1499" height="436" alt="image" src="https://github.com/user-attachments/assets/8c869b4f-7dc6-48b7-868b-5a52e49eed49" />
