### PR TITLE
Permettre aux admins de territoire d'autoriser les rendez-vous le dimanche et les jours fériés

### DIFF
--- a/app/controllers/admin/territories/calendar_settings_controller.rb
+++ b/app/controllers/admin/territories/calendar_settings_controller.rb
@@ -1,0 +1,12 @@
+class Admin::Territories::CalendarSettingsController < Admin::Territories::BaseController
+  def edit
+    authorize(current_territory, policy_class: Agent::TerritoryPolicy)
+  end
+
+  def update
+    authorize(current_territory, policy_class: Agent::TerritoryPolicy)
+    current_territory.update(params.require(:territory).permit(:work_on_sunday))
+    flash[:success] = "Configuration de calendrier enregistrée"
+    redirect_to action: :edit
+  end
+end

--- a/app/views/admin/territories/calendar_settings/edit.html.slim
+++ b/app/views/admin/territories/calendar_settings/edit.html.slim
@@ -1,0 +1,18 @@
+= territory_navigation("Paramètres de calendrier")
+
+.fr-grid-row.justify-content-center
+  .fr-col-md-6
+    .card
+      .card-body
+        = form_for current_territory, url: admin_territory_calendar_settings_path(current_territory), builder: Dsfr::FormBuilder do |f|
+          = render "model_errors", model: current_territory
+
+          h1.fr-h2.card-title= "Paramètres de calendrier"
+          p.fr-text-mention--grey.fr-hint-text
+            | Par défaut, les dimanches sont cachés du calendrier et les jours fériés sont automatiquement considérés comme des absences.
+          p.fr-text-mention--grey.fr-hint-text
+            | Cependant, si votre service travaille le dimanche ou certains jours fériés, vous pouvez activer cette option pour permettre la prise de rendez-vous pour ces jours.
+
+          = f.dsfr_check_box :work_on_sunday, label: "Autoriser les rendez-vous le dimanche et les jours fériés"
+          .text-right
+            = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/territories/edit.html.slim
+++ b/app/views/admin/territories/edit.html.slim
@@ -1,12 +1,11 @@
 = territory_navigation(t(".title", name: current_territory.name_for_agent))
 
 .card
-  .card-header
-    h5.card-title Configuration générale
-  = simple_form_for([:admin, @territory]) do |f|
-    .card-body
+  .card-body
+    h1.fr-h2.card-title Nom de votre espace
+    = simple_form_for([:admin, @territory]) do |f|
       = f.input :name
       = f.input :departement_number, disabled: true
 
-    .card-footer.text-right
-      = f.submit class: "fr-btn"
+      .text-right
+        = f.submit class: "fr-btn"

--- a/app/views/admin/territories/motif_fields/edit.html.slim
+++ b/app/views/admin/territories/motif_fields/edit.html.slim
@@ -1,13 +1,13 @@
 = territory_navigation(t(".title"))
 
-.row.justify-content-center
-  .col-md-6
+.fr-grid-row.justify-content-center
+  .fr-col-md-8
     .card
       .card-body
         = form_for current_territory, url: admin_territory_motif_categories_path(current_territory), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: current_territory
 
-          h1.card-title= t(".card_title")
+          h1.fr-h2= t(".card_title")
           p.fr-text-mention--grey.font-14= t(".hint_1")
 
           h6= t("admin.territories.motif_categories.edit.title")

--- a/app/views/admin/territories/rdv_fields/edit.html.slim
+++ b/app/views/admin/territories/rdv_fields/edit.html.slim
@@ -1,7 +1,7 @@
 = territory_navigation(t(".title"))
 
-.row.justify-content-center
-  .col-md-8
+.fr-grid-row.justify-content-center
+  .fr-col-md-8
     .card
       .card-body
         = form_for current_territory, url: admin_territory_rdv_fields_path(current_territory), builder: Dsfr::FormBuilder do |f|

--- a/app/views/admin/territories/rdv_fields/edit.html.slim
+++ b/app/views/admin/territories/rdv_fields/edit.html.slim
@@ -1,13 +1,13 @@
 = territory_navigation(t(".title"))
 
 .row.justify-content-center
-  .col-md-6
+  .col-md-8
     .card
       .card-body
         = form_for current_territory, url: admin_territory_rdv_fields_path(current_territory), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: current_territory
 
-          h1.card-title= t(".card_title")
+          h1.fr-h2= t(".card_title")
           p.fr-text-mention--grey.font-14= t(".hint_1")
           p.fr-text-mention--grey.font-14= t(".hint_2")
 
@@ -21,7 +21,7 @@
         = form_for current_territory, url: admin_territory_rdv_fields_path(current_territory), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: current_territory
 
-          h1.card-title= t(".waiting_room_title")
+          h1.fr-h2= t(".waiting_room_title")
           p.fr-text-mention--grey.font-14= t(".waiting_room_config_hint")
 
           - Territory::OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.each do |toggle, field_name|

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -4,7 +4,7 @@
   .fr-col-md-10
     .card
       .card-body
-        h1.card-title Services
+        h1.fr-h2 Services
         p Les services vous permettent de classifier vos motifs pour éviter que tous les agents aient accès à tous les rendez-vous.
 
         p Par exemple, si vous créez un motif « Entretien annuel » pour le service « Ressources Humaines », seuls les agents du service « Ressources Humaines » pourront assurer des rendez-vous pour ce motif. Les agents des autres services ne pourront pas les voir ni les modifier, sauf s'ils sont secrétaires ou admin.

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,10 +1,10 @@
 - content_for :title, "Paramètres de #{current_territory.name_for_agent}"
 
-= link_to(root_path, class: "pt-1 pb-4") do
-  = icon("fr-icon-arrow-left-line")
-  |< Retour à l'accueil
+= link_to(root_path, class: "fr-btn fr-btn--tertiary-no-outline") do
+  = icon("fr-icon-sm fr-icon-arrow-left-line fr-mr-1w")
+  | Retour à l'accueil
 
-h1.fr-my-2w.rdv-text-align-center.fr-pb-2w =  t("admin.territories.show.title", territory: current_territory.name_for_agent)
+h1.fr-h2.fr-my-2w.fr-pb-2w =  t("admin.territories.show.title", territory: current_territory.name_for_agent)
 
 .fr-container-fluid
   .fr-grid-row.fr-grid-row--gutters
@@ -72,8 +72,21 @@ h1.fr-my-2w.rdv-text-align-center.fr-pb-2w =  t("admin.territories.show.title", 
           .fr-tile__header
             .fr-tile__pictogram
               = dsfr_svg "artwork/pictograms/digital/search"
+    - if Agent::TerritoryPolicy.new(current_agent, current_territory).edit?
+      .fr-col-12.fr-col-md-6.fr-col-lg-4.fr-mb-2w
+        .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+          .fr-tile__body
+            .fr-tile__content
+              h2.fr-tile__title
+                = link_to edit_admin_territory_services_path(current_territory) do
+                  | Calendrier
+              .fr-tile__desc
+                | Gestion des jours fériés, des dimanches et des fuseaux horaires
+          .fr-tile__header
+            .fr-tile__pictogram
+              = dsfr_svg "artwork/pictograms/digital/search"
 
-h2.rdv-text-align-center.fr-pt-4w.fr-pb-2w Paramètres avancés
+h1.fr-h3.fr-pt-4w.fr-pb-2w Paramètres avancés
 
 .fr-container-fluid
   .fr-grid-row.fr-grid-row--gutters

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -78,13 +78,13 @@ h1.fr-h2.fr-my-2w.fr-pb-2w =  t("admin.territories.show.title", territory: curre
           .fr-tile__body
             .fr-tile__content
               h2.fr-tile__title
-                = link_to edit_admin_territory_services_path(current_territory) do
+                = link_to edit_admin_territory_calendar_settings_path(current_territory) do
                   | Calendrier
               .fr-tile__desc
-                | Gestion des jours fériés, des dimanches et des fuseaux horaires
+                | Gestion des jours fériés et des dimanches
           .fr-tile__header
             .fr-tile__pictogram
-              = dsfr_svg "artwork/pictograms/digital/search"
+              = dsfr_svg "artwork/pictograms/digital/calendar"
 
 h1.fr-h3.fr-pt-4w.fr-pb-2w Paramètres avancés
 

--- a/app/views/admin/territories/user_fields/edit.html.slim
+++ b/app/views/admin/territories/user_fields/edit.html.slim
@@ -1,13 +1,13 @@
 = territory_navigation(t(".title"))
 
-.row.justify-content-center
-  .col-md-6
+.fr-grid-row.justify-content-center
+  .fr-col-md-8
     .card
       .card-body
         = form_for current_territory, url: admin_territory_user_fields_path(current_territory), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: current_territory
 
-          h5.card-title= t(".card_title")
+          h1.fr-h2= t(".card_title")
 
           p.fr-text-mention--grey.font-14= t(".hint_1")
           p.fr-text-mention--grey.font-14= t(".hint_2")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,6 +249,7 @@ Rails.application.routes.draw do
         end
         resource :user_fields, only: %i[edit update]
         resource :rdv_fields, only: %i[edit update]
+        resource :calendar_settings, only: %i[edit update]
         resource :motif_fields, only: %i[edit update]
         resource :motif_categories, only: %i[update]
         resources :zone_imports, only: %i[new create]

--- a/spec/features/territory_admins/calendar_settings_spec.rb
+++ b/spec/features/territory_admins/calendar_settings_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "Les admins de territoire peuvent gérer le travail pour les jours fériés et les dimanches" do
+  let!(:territory) { create(:territory) }
+  let!(:agent) { create(:agent, role_in_territories: [territory]) }
+
+  specify do
+    login_as(agent, scope: :agent)
+    visit edit_admin_territory_calendar_settings_path(territory)
+
+    check "Autoriser les rendez-vous le dimanche et les jours fériés"
+    expect { click_on "Enregistrer" }.to change { territory.reload.work_on_sunday }.from(false).to(true)
+
+    uncheck "Autoriser les rendez-vous le dimanche et les jours fériés"
+    expect { click_on "Enregistrer" }.to change { territory.reload.work_on_sunday }.from(true).to(false)
+  end
+end


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1412" height="702" alt="Screenshot 2026-08-19 at 12 10 48" src="https://github.com/user-attachments/assets/64f55bc1-f8c8-426d-837c-e148f8c4911f" />| <img width="1411" height="713" alt="Screenshot 2026-08-19 at 12 10 33" src="https://github.com/user-attachments/assets/7b314df1-b469-42b8-8d04-194263c634f1" />
<img width="1122" height="430" alt="Screenshot 2026-08-19 at 12 11 04" src="https://github.com/user-attachments/assets/eb3e6a45-959e-40c2-abce-81d38034cc9a" />

# Contexte

On a eu un ticket zammad d'un agent qui demandait à faire des rendez-vous le dimanche et les jours fériés.

Cette option n'est actuellement activable que depuis le super admin, et nécessite donc un ticket au support et une intervention de notre part.

# Solution

Pour éviter cette surcharge et rendre la feature plus facile à découvrir, on ajoute une entrée dans le menu de l'espace admin pour les options de calendrier.
Ça sera un bon endroit pour ajouter la gestion des fuseaux horaires plus tard.

Au passage, je normalise aussi les styles des heading des pages de l'espace admin pour utiliser les styles du dsfr plutôt que de bootstrap.

J'ai une toute petite hésitation : est-ce que ça devrait être dans les paramètres avancés ou les paramètres normaux ?

