### PR TITLE
Ajout d’un nom et d’une couleur d’affichage pour le calendrier Caldav

### DIFF
--- a/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
+++ b/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
@@ -29,7 +29,7 @@ class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseCon
   def external_event_title(calendar_name)
     return "Indisponibilité provenant d’un agenda externe" if calendar_name.blank?
 
-    "Indisponibilité provenant de #{calendar_name}"
+    "#{calendar_name} - Indisponibilité synchronisée"
   end
 
   def agents

--- a/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
+++ b/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
@@ -1,7 +1,7 @@
 class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseController
   def index
     agents_with_caldav_config = agents.select(&:caldav_configured?)
-    calendar_names_by_agent_id = agents_with_caldav_config.to_h { |agent| [agent.id, agent.caldav_config.caldav_calendar_name] }
+    caldav_configs_by_agent_id = agents_with_caldav_config.to_h { |agent| [agent.id, agent.caldav_config] }
 
     external_calendar_events = ExternalCalendarEvent
       .within_range(time_range_params)
@@ -9,12 +9,13 @@ class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseCon
 
     external_calendar_occurrences = []
     external_calendar_events.each do |event|
+      caldav_config = caldav_configs_by_agent_id[event.agent_id]
       event.all_occurrences_within(time_range_params).each do |occurrence|
         external_calendar_occurrences << {
-          title: external_event_title(calendar_names_by_agent_id[event.agent_id]),
+          title: external_event_title(caldav_config.caldav_calendar_name),
           start: occurrence.starts_at.as_json,
           end: occurrence.ends_at.as_json,
-          color: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
+          color: caldav_config.caldav_calendar_color.presence || AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
           resourceIds: [event.agent_id], # https://fullcalendar.io/docs/resources-and-events
         }
       end

--- a/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
+++ b/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
@@ -1,14 +1,17 @@
 class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseController
   def index
+    agents_with_caldav_config = agents.select(&:caldav_configured?)
+    calendar_names_by_agent_id = agents_with_caldav_config.to_h { |agent| [agent.id, agent.caldav_config.caldav_calendar_name] }
+
     external_calendar_events = ExternalCalendarEvent
       .within_range(time_range_params)
-      .where(agent: agents.select(&:caldav_configured?))
+      .where(agent: agents_with_caldav_config)
 
     external_calendar_occurrences = []
     external_calendar_events.each do |event|
       event.all_occurrences_within(time_range_params).each do |occurrence|
         external_calendar_occurrences << {
-          title: "Indisponibilité provenant d’un agenda externe",
+          title: external_event_title(calendar_names_by_agent_id[event.agent_id]),
           start: occurrence.starts_at.as_json,
           end: occurrence.ends_at.as_json,
           color: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
@@ -21,6 +24,12 @@ class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseCon
   end
 
   private
+
+  def external_event_title(calendar_name)
+    return "Indisponibilité provenant d’un agenda externe" if calendar_name.blank?
+
+    "Indisponibilité provenant de #{calendar_name}"
+  end
 
   def agents
     if Array(params[:agent_id]).compact_blank.map(&:to_i) == [current_agent.id]

--- a/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
+++ b/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
@@ -39,7 +39,7 @@ class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseCon
       # La scope de policy pour ExternalCalendarEvent délèguent à Agent::AgentPolicy::Scope.
       # Afin d'améliorer les perfs ici, il est préférable de simplement charger les agents via Agent::AgentPolicy::Scope
       # puis de passer cette liste d'agents en WHERE aux requêtes d'Absence et ExternalCalendarEvent.
-      Agent::AgentPolicy::Scope.new(pundit_user, Agent.all).resolve.where(id: params[:agent_id]).load
+      Agent::AgentPolicy::Scope.new(pundit_user, Agent.includes(:caldav_config)).resolve.where(id: params[:agent_id]).load
     end
   end
 end

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -66,7 +66,7 @@ class Agents::CaldavSyncController < AgentAuthController
   private
 
   def permitted_params
-    params.permit(:caldav_agenda_url, :caldav_username, :caldav_password, :caldav_include_sensitive_data, :caldav_calendar_name)
+    params.permit(:caldav_agenda_url, :caldav_username, :caldav_password, :caldav_include_sensitive_data, :caldav_calendar_name, :caldav_calendar_color)
   end
 
   # Vérifie la configuration CalDAV en 3 étapes : authentification, lecture, écriture.

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -66,7 +66,7 @@ class Agents::CaldavSyncController < AgentAuthController
   private
 
   def permitted_params
-    params.permit(:caldav_agenda_url, :caldav_username, :caldav_password, :caldav_include_sensitive_data)
+    params.permit(:caldav_agenda_url, :caldav_username, :caldav_password, :caldav_include_sensitive_data, :caldav_calendar_name)
   end
 
   # Vérifie la configuration CalDAV en 3 étapes : authentification, lecture, écriture.

--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -1,5 +1,7 @@
 module AbsencesHelper
   CALENDAR_BACKGROUND_COLOR = "rgba(52, 57, 58, 0.7)".freeze
+  # Équivalent hexadécimal de CALENDAR_BACKGROUND_COLOR (sans transparence), pour les usages qui ne supportent pas le format rgba (ex : input[type=color]).
+  CALENDAR_BACKGROUND_COLOR_HEX = "#34393A".freeze
 
   def absence_tag(absence)
     if absence.expired?

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -197,3 +197,7 @@ input:placeholder-shown {
 .rdv-three-letters-form input[type="text"] {
   max-width: 8rem;
 }
+
+.fr-input[type="color"] {
+  height: 2.5rem;
+}

--- a/app/models/caldav_config.rb
+++ b/app/models/caldav_config.rb
@@ -3,6 +3,8 @@ class CaldavConfig < ApplicationRecord
 
   belongs_to :agent
 
+  validates :caldav_calendar_color, css_hex_color: true, allow_blank: true
+
   def caldav_client
     @caldav_client ||= Calendav::Client.new(
       Calendav::Credentials::Standard.new(

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -21,7 +21,7 @@
           = f.dsfr_select :service_id, available_services.collect { |service| [service.name, service.id] }, { include_blank: "Aucun" }, label: "Service associé", hint: "Facultatif"
       .fr-col-md-6= f.dsfr_number_field :default_duration_in_min, label: "Durée du RDV (en minutes)"
       // Le DSFR ne propose pas d’input color, on utilise donc le champ classique avec le style DSFR pour lequel on fixe la hauteur.
-      .fr-col-md-6= f.dsfr_input_field :color, :color_field, label: "Couleur associée", style: "height: 2.5rem"
+      .fr-col-md-6= f.dsfr_input_field :color, :color_field, label: "Couleur associée"
 
 .card
   .card-body.fr-pb-0

--- a/app/views/agents/caldav_sync/calendar_selection.html.slim
+++ b/app/views/agents/caldav_sync/calendar_selection.html.slim
@@ -14,6 +14,7 @@ p Veuillez sélectionner ci-dessous l'agenda que vous souhaitez synchroniser ave
   = hidden_field_tag :caldav_username, params[:caldav_username]
   = hidden_field_tag :caldav_password, params[:caldav_password]
   = hidden_field_tag :caldav_include_sensitive_data, params[:caldav_include_sensitive_data]
+  = hidden_field_tag :caldav_calendar_name, params[:caldav_calendar_name]
 
   fieldset.fr-fieldset
     legend.fr-fieldset__legend.fr-fieldset__legend--regular

--- a/app/views/agents/caldav_sync/calendar_selection.html.slim
+++ b/app/views/agents/caldav_sync/calendar_selection.html.slim
@@ -15,6 +15,7 @@ p Veuillez sélectionner ci-dessous l'agenda que vous souhaitez synchroniser ave
   = hidden_field_tag :caldav_password, params[:caldav_password]
   = hidden_field_tag :caldav_include_sensitive_data, params[:caldav_include_sensitive_data]
   = hidden_field_tag :caldav_calendar_name, params[:caldav_calendar_name]
+  = hidden_field_tag :caldav_calendar_color, params[:caldav_calendar_color]
 
   fieldset.fr-fieldset
     legend.fr-fieldset__legend.fr-fieldset__legend--regular

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -9,9 +9,13 @@
 p.fr-badge.fr-badge--pink-tuile Beta
 
 p
-  |> Vos rendez-vous pris via RDV Service Public s’ajoutent automatiquement à votre agenda professionnel.
-  |> À l’inverse, vos événements existants rendent automatiquement les créneaux correspondants indisponibles dans RDV Service Public.
-  |> Pour utiliser cette fonctionnalité, vous devez disposer d’un agenda compatible CalDAV (comme celui de
+  |> Synchronisez RDV Service Public et votre agenda professionnel dans les deux sens :
+  ul
+    li
+      |> vos rendez-vous RDV Service Public sont automatiquement ajoutés à votre agenda ;
+    li
+      |> les événements de votre agenda rendent les créneaux correspondants indisponibles dans RDV Service Public.
+  |> Vous devez disposer d’un agenda compatible CalDAV (comme celui de
   = link_to "LaSuite", "https://lasuite.numerique.gouv.fr/"
   | ).
 

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -37,6 +37,10 @@ p
         p.fr-my-2w Votre agenda est synchronisé avec l'agenda CalDAV #{current_agent.caldav_config.caldav_username}.
         - if current_agent.caldav_config.caldav_calendar_name.present?
           p.fr-my-2w Nom d’affichage : #{current_agent.caldav_config.caldav_calendar_name}.
+        - if current_agent.caldav_config.caldav_calendar_color.present?
+          p.fr-my-2w
+            | Couleur d’affichage :
+            span.fr-icon-circle-fill[style="color: #{current_agent.caldav_config.caldav_calendar_color}" aria-hidden="true"]
       .fr-btns-group.fr-btns-group--inline
         - if current_agent.organisations.any?
           = link_to("Voir mon agenda", admin_organisation_planning_agenda_path(current_agent.organisations.first), class: "fr-btn fr-btn--secondary")
@@ -65,6 +69,12 @@ p
         span.fr-hint-text
           | Optionnel. Ce nom sera utilisé dans le planning pour vous indiquer les indisponibilités provenant de votre agenda externe.
       input#caldav_calendar_name.fr-input[type="text" name="caldav_calendar_name"]
+    .fr-input-group
+      label.fr-label for="caldav_calendar_color"
+        | Couleur d’affichage de l’agenda
+        span.fr-hint-text
+          | Optionnel. Cette couleur sera utilisée pour afficher les indisponibilités dans le planning.
+      input#caldav_calendar_color.fr-input[type="color" name="caldav_calendar_color" value=AbsencesHelper::CALENDAR_BACKGROUND_COLOR_HEX]
     fieldset.fr-fieldset
       legend.fr-fieldset__legend--regular.fr-fieldset__legend
         | Données personnelles dans l'agenda externe

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -94,6 +94,6 @@ p
           label.fr-label for="caldav_calendar_color"
             | Couleur d’affichage de l’agenda
             span.fr-hint-text
-              | Optionnel. Cette couleur sera utilisée pour afficher les indisponibilités dans le planning.
+              | Optionnel. Cette couleur sera utilisée dans le planning pour vous indiquer les indisponibilités provenant de votre agenda externe.
           input#caldav_calendar_color.fr-input[type="color" name="caldav_calendar_color" value=AbsencesHelper::CALENDAR_BACKGROUND_COLOR_HEX]
     = submit_tag "Enregistrer", class: "fr-btn"

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -48,48 +48,57 @@ p
           = submit_tag "Supprimer la configuration CalDAV", class: "fr-btn fr-btn--tertiary", data: { confirm: "Êtes-vous sûr de vouloir supprimer vos identifiants CalDAV ?" }
 - else
   = form_tag calendar_selection_agents_calendar_sync_caldav_sync_path, method: :post do
-    .fr-input-group
-      label.fr-label for="caldav_username"
-        | Identifiant de l’agenda CalDAV
-        span.fr-hint-text
-          = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
-      input#caldav_username.fr-input[type="text" name="caldav_username" required]
-    .fr-input-group
-      label.fr-label for="caldav_password"
-        | Mot de passe de l’agenda CalDAV
-        span.fr-hint-text
-          = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
-      input#caldav_password.fr-input[type="password" name="caldav_password" required]
-    .fr-input-group
-      label.fr-label for="caldav_agenda_url" URL du serveur ou de l’agenda CalDAV
-      input#caldav_agenda_url.fr-input[type="text" name="caldav_agenda_url" required]
-    .fr-input-group
-      label.fr-label for="caldav_calendar_name"
-        | Nom d’affichage de l’agenda
-        span.fr-hint-text
-          | Optionnel. Ce nom sera utilisé dans le planning pour vous indiquer les indisponibilités provenant de votre agenda externe.
-      input#caldav_calendar_name.fr-input[type="text" name="caldav_calendar_name"]
-    .fr-input-group
-      label.fr-label for="caldav_calendar_color"
-        | Couleur d’affichage de l’agenda
-        span.fr-hint-text
-          | Optionnel. Cette couleur sera utilisée pour afficher les indisponibilités dans le planning.
-      input#caldav_calendar_color.fr-input[type="color" name="caldav_calendar_color" value=AbsencesHelper::CALENDAR_BACKGROUND_COLOR_HEX]
-    fieldset.fr-fieldset
-      legend.fr-fieldset__legend--regular.fr-fieldset__legend
-        | Données personnelles dans l'agenda externe
-      .fr-fieldset__element
-        .fr-radio-group
-          input#caldav_include_sensitive_data_false type="radio" name="caldav_include_sensitive_data" value="false" checked="checked"
-          label.fr-label for="caldav_include_sensitive_data_false"
-            | Anonymiser les informations du rendez-vous
+    .card.fr-mb-3w
+      .card-body
+        h5.card-title Informations de connexion
+        .fr-input-group
+          label.fr-label for="caldav_username"
+            | Identifiant de l’agenda CalDAV
             span.fr-hint-text
-              | Cette option vous permet de ne pas transmettre de données personnelles liées aux rendez-vous à votre agenda externe.
-      .fr-fieldset__element
-        .fr-radio-group
-          input#caldav_include_sensitive_data_true type="radio" name="caldav_include_sensitive_data" value="true"
-          label.fr-label for="caldav_include_sensitive_data_true"
-            | Inclure les données personnelles liées au rendez-vous dans mon agenda externe
+              = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
+          input#caldav_username.fr-input[type="text" name="caldav_username" required]
+        .fr-input-group
+          label.fr-label for="caldav_password"
+            | Mot de passe de l’agenda CalDAV
             span.fr-hint-text
-              | Cette option est plus pratique, mais les autres personnes qui ont accès à votre agenda externe auront accès aux données personnelles liées au rendez-vous.
+              = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
+          input#caldav_password.fr-input[type="password" name="caldav_password" required]
+        .fr-input-group
+          label.fr-label for="caldav_agenda_url" URL du serveur ou de l’agenda CalDAV
+          input#caldav_agenda_url.fr-input[type="text" name="caldav_agenda_url" required]
+    .card.fr-mb-3w
+      .card-body
+        h5.card-title Confidentialité des données
+        fieldset.fr-fieldset
+          legend.fr-fieldset__legend--regular.fr-fieldset__legend
+            | Données personnelles dans l'agenda externe
+          .fr-fieldset__element
+            .fr-radio-group
+              input#caldav_include_sensitive_data_false type="radio" name="caldav_include_sensitive_data" value="false" checked="checked"
+              label.fr-label for="caldav_include_sensitive_data_false"
+                | Anonymiser les informations du rendez-vous
+                span.fr-hint-text
+                  | Cette option vous permet de ne pas transmettre de données personnelles liées aux rendez-vous à votre agenda externe.
+          .fr-fieldset__element
+            .fr-radio-group
+              input#caldav_include_sensitive_data_true type="radio" name="caldav_include_sensitive_data" value="true"
+              label.fr-label for="caldav_include_sensitive_data_true"
+                | Inclure les données personnelles liées au rendez-vous dans mon agenda externe
+                span.fr-hint-text
+                  | Cette option est plus pratique, mais les autres personnes qui ont accès à votre agenda externe auront accès aux données personnelles liées au rendez-vous.
+    .card.fr-mb-3w
+      .card-body
+        h5.card-title Personnalisation (optionnelle)
+        .fr-input-group
+          label.fr-label for="caldav_calendar_name"
+            | Nom d’affichage de l’agenda
+            span.fr-hint-text
+              | Optionnel. Ce nom sera utilisé dans le planning pour vous indiquer les indisponibilités provenant de votre agenda externe.
+          input#caldav_calendar_name.fr-input[type="text" name="caldav_calendar_name"]
+        .fr-input-group
+          label.fr-label for="caldav_calendar_color"
+            | Couleur d’affichage de l’agenda
+            span.fr-hint-text
+              | Optionnel. Cette couleur sera utilisée pour afficher les indisponibilités dans le planning.
+          input#caldav_calendar_color.fr-input[type="color" name="caldav_calendar_color" value=AbsencesHelper::CALENDAR_BACKGROUND_COLOR_HEX]
     = submit_tag "Enregistrer", class: "fr-btn"

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -20,11 +20,6 @@ p
   = external_link_to "documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
   | .
 
-= dsfr_callout(icon_name: :none) do
-  |> Pour le moment, cette fonctionnalité est en version bêta. Pour toute question ou remontée de bug, merci de
-  = external_link_to("contacter le support", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation CalDAV"))
-  | .
-
 - if current_agent.caldav_config&.caldav_disconnect_started_at.present?
     p
       |> Les événements qui avaient été importés dans votre agenda sont en cours de suppression. Cela peut prendre quelques minutes.

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -35,6 +35,8 @@ p
       .fr-mb-2w
         .fr-badge.fr-badge--success Synchronisation active
         p.fr-my-2w Votre agenda est synchronisé avec l'agenda CalDAV #{current_agent.caldav_config.caldav_username}.
+        - if current_agent.caldav_config.caldav_calendar_name.present?
+          p.fr-my-2w Nom d’affichage : #{current_agent.caldav_config.caldav_calendar_name}.
       .fr-btns-group.fr-btns-group--inline
         - if current_agent.organisations.any?
           = link_to("Voir mon agenda", admin_organisation_planning_agenda_path(current_agent.organisations.first), class: "fr-btn fr-btn--secondary")
@@ -57,6 +59,12 @@ p
     .fr-input-group
       label.fr-label for="caldav_agenda_url" URL du serveur ou de l’agenda CalDAV
       input#caldav_agenda_url.fr-input[type="text" name="caldav_agenda_url" required]
+    .fr-input-group
+      label.fr-label for="caldav_calendar_name"
+        | Nom d’affichage de l’agenda
+        span.fr-hint-text
+          | Optionnel. Ce nom sera utilisé dans le planning pour vous indiquer les indisponibilités provenant de votre agenda externe.
+      input#caldav_calendar_name.fr-input[type="text" name="caldav_calendar_name"]
     fieldset.fr-fieldset
       legend.fr-fieldset__legend--regular.fr-fieldset__legend
         | Données personnelles dans l'agenda externe

--- a/db/migrate/20260819121548_add_caldav_calendar_name_and_color_to_caldav_configs.rb
+++ b/db/migrate/20260819121548_add_caldav_calendar_name_and_color_to_caldav_configs.rb
@@ -1,0 +1,6 @@
+class AddCaldavCalendarNameAndColorToCaldavConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :caldav_configs, :caldav_calendar_name, :string
+    add_column :caldav_configs, :caldav_calendar_color, :string, limit: 7
+  end
+end

--- a/db/migrate/20260819121548_add_caldav_calendar_name_to_caldav_configs.rb
+++ b/db/migrate/20260819121548_add_caldav_calendar_name_to_caldav_configs.rb
@@ -1,5 +1,0 @@
-class AddCaldavCalendarNameToCaldavConfigs < ActiveRecord::Migration[8.0]
-  def change
-    add_column :caldav_configs, :caldav_calendar_name, :string
-  end
-end

--- a/db/migrate/20260819121548_add_caldav_calendar_name_to_caldav_configs.rb
+++ b/db/migrate/20260819121548_add_caldav_calendar_name_to_caldav_configs.rb
@@ -1,0 +1,5 @@
+class AddCaldavCalendarNameToCaldavConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :caldav_configs, :caldav_calendar_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -233,6 +233,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_24_085938) do
     t.boolean "caldav_include_sensitive_data", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "caldav_calendar_name"
     t.index ["agent_id"], name: "index_caldav_configs_on_agent_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,6 +234,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_24_085938) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "caldav_calendar_name"
+    t.string "caldav_calendar_color", limit: 7
     t.index ["agent_id"], name: "index_caldav_configs_on_agent_id", unique: true
   end
 

--- a/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe Admin::Api::Agenda::ExternalCalendarEventsController, type: :cont
     expect(response.parsed_body).to match_array(expected_response)
   end
 
+  it "uses the caldav calendar name in the title when present" do
+    agent = create(:agent, :with_caldav_config)
+    agent.caldav_config.update!(caldav_calendar_name: "Agenda perso")
+    sign_in agent
+
+    ExternalCalendarEvent.create!(agent:, url: "1234", starts_at: today_at(10, 30), ends_at: today_at(12))
+
+    current_week = Time.zone.now.beginning_of_week.beginning_of_day..Time.zone.now.end_of_week.end_of_day
+    get :index, params: { agent_id: agent.id, start: current_week.begin, end: current_week.end, format: :json }
+
+    expect(response.parsed_body).to contain_exactly(hash_including("title" => "Indisponibilité provenant de Agenda perso"))
+  end
+
   it "returns unauthorized if agent is not logged in" do
     get :index, params: { agent_id: 1, organisation_id: 1, start: Date.new(2019, 8, 12), end: Date.new(2019, 8, 19), format: :json }
     expect(response).to be_unauthorized

--- a/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Admin::Api::Agenda::ExternalCalendarEventsController, type: :cont
     current_week = Time.zone.now.beginning_of_week.beginning_of_day..Time.zone.now.end_of_week.end_of_day
     get :index, params: { agent_id: agent.id, start: current_week.begin, end: current_week.end, format: :json }
 
-    expect(response.parsed_body).to contain_exactly(hash_including("title" => "Indisponibilité provenant de Agenda perso"))
+    expect(response.parsed_body).to contain_exactly(hash_including("title" => "Agenda perso - Indisponibilité synchronisée"))
   end
 
   it "uses the caldav calendar color when present" do

--- a/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe Admin::Api::Agenda::ExternalCalendarEventsController, type: :cont
     expect(response.parsed_body).to contain_exactly(hash_including("title" => "Indisponibilité provenant de Agenda perso"))
   end
 
+  it "uses the caldav calendar color when present" do
+    agent = create(:agent, :with_caldav_config)
+    agent.caldav_config.update!(caldav_calendar_color: "#3388FF")
+    sign_in agent
+
+    ExternalCalendarEvent.create!(agent:, url: "1234", starts_at: today_at(10, 30), ends_at: today_at(12))
+
+    current_week = Time.zone.now.beginning_of_week.beginning_of_day..Time.zone.now.end_of_week.end_of_day
+    get :index, params: { agent_id: agent.id, start: current_week.begin, end: current_week.end, format: :json }
+
+    expect(response.parsed_body).to contain_exactly(hash_including("color" => "#3388FF"))
+  end
+
   it "returns unauthorized if agent is not logged in" do
     get :index, params: { agent_id: 1, organisation_id: 1, start: Date.new(2019, 8, 12), end: Date.new(2019, 8, 19), format: :json }
     expect(response).to be_unauthorized

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Agents::CaldavSyncController, type: :controller do
       get :show
       expect(response).to have_http_status(:ok)
     end
+
+    it "pré-remplit le sélecteur de couleur avec la couleur par défaut des indisponibilités" do
+      get :show
+      color_input = Capybara.string(response.body).find("#caldav_calendar_color")
+      expect(color_input[:type]).to eq("color")
+      expect(color_input[:value]).to eq(AbsencesHelper::CALENDAR_BACKGROUND_COLOR_HEX)
+    end
   end
 
   describe "#update" do

--- a/spec/models/caldav_config_spec.rb
+++ b/spec/models/caldav_config_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe CaldavConfig do
+  it "is valid without a caldav_calendar_color" do
+    expect(build(:caldav_config, caldav_calendar_color: nil)).to be_valid
+  end
+
+  it "invalid without #RRGGBB format's caldav_calendar_color" do
+    expect(build(:caldav_config, caldav_calendar_color: "bleu")).to be_invalid
+    expect(build(:caldav_config, caldav_calendar_color: "003399")).to be_invalid
+    expect(build(:caldav_config, caldav_calendar_color: "#003399")).to be_valid
+  end
+end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6620.osc-secnum-fr1.scalingo.io/)

# Contexte

Lorsqu'un agent synchronise son agenda externe via CalDAV, les indisponibilités importées apparaissent dans le planning avec un libellé générique ("Indisponibilité provenant d'un agenda externe") et une couleur fixe, sans distinction possible entre plusieurs agendas externes ni personnalisation de l'affichage.

# Solution

- Ajout de deux nouveaux champs sur `CaldavConfig` : `caldav_calendar_name` (nom d'affichage) et `caldav_calendar_color`
- Le formulaire de configuration CalDAV permet désormais de saisir un nom et de choisir une couleur
- Le titre et la couleur affichés dans le planning pour les événements CalDAV utilisent désormais ce nom et cette couleur quand ils sont renseignés, avec un repli sur le comportement générique existant sinon.
- La page de statut de synchronisation affiche le nom et la couleur configurés.


## Captures d'écran

<img width="371" height="370" alt="image" src="https://github.com/user-attachments/assets/b6cf8655-78df-4e2a-87fd-ed8793a4c044" />

<img width="602" height="699" alt="image" src="https://github.com/user-attachments/assets/fc7a6b6b-2b9b-49bc-9b15-c691b69bed4f" />


