### PR TITLE
Fixer les versions de Postgres et Redis dans les review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -59,10 +59,16 @@
   },
   "addons": [
     {
-      "plan": "postgresql:postgresql-starter-512"
+      "plan": "postgresql:postgresql-starter-512",
+      "options": {
+        "version": "16"
+      }
     },
     {
-      "plan": "redis:redis-starter-256"
+      "plan": "redis:redis-starter-256",
+      "options": {
+        "version": "7"
+      }
     }
   ],
   "formation": {


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6627.osc-secnum-fr1.scalingo.io/)

Contexte : je viens de remarquer qu'on était en Postgres v17 sur les reviews apps, alors qu'on est en v16 en prod. 

Puisque les review apps servent parfois à tester comment une nouvelle config ou feature se comporte sur Scalingo, il est préférable que les review apps aient les mêmes versions d'add-ons que les prods.
