### PR TITLE
Ajout du menu Réservation en ligne pour tous les agents

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -6,10 +6,14 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
     set_motifs
 
     if @motifs.bookable_by_everyone.none?
-      @online_booking_motifs_form = Admin::OnlineBookingMotifsForm.new(current_organisation)
+      if current_agent.admin_in_organisation?(current_organisation)
+        @online_booking_motifs_form = Admin::OnlineBookingMotifsForm.new(current_organisation)
 
-      @cancel_path = admin_organisation_configuration_path(current_organisation)
-      render :form
+        @cancel_path = admin_organisation_configuration_path(current_organisation)
+        render :form
+      else
+        render :not_configured
+      end
     else
       @open_motifs = @motifs.bookable_by_everyone
       @closed_motifs = @motifs.where.not(bookable_by: :everyone)

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -37,13 +37,10 @@
         .fr-hint-text
           = sanitize(@motif.human_attribute_value(:location_type, context: :hint), scrubber: :prune)
 
-    .card[class="#{"fr-enlarge-link" if current_agent.admin_in_organisation?(current_organisation)}"]
+    .card.fr-enlarge-link
       .card-body
         .d-flex.rdv-align-items-baseline
-          - if current_agent.admin_in_organisation?(current_organisation)
-            h2.fr-h5.fr-mr-2w = link_to "Réservation en ligne", admin_organisation_online_booking_motif_path(current_organisation, @motif)
-          - else
-            h2.fr-h5.fr-mr-2w Réservation en ligne
+          h2.fr-h5.fr-mr-2w = link_to "Réservation en ligne", admin_organisation_online_booking_motif_path(current_organisation, @motif)
 
           = render "admin/organisations/online_booking/motifs/availability_badge", motif: @motif, availabilities_count: @motif.upcoming_availabilities.count
 
@@ -53,8 +50,7 @@
           - else
             = render "admin/organisations/online_booking/motifs/bookable_by_text", motif: @motif
 
-          - if current_agent.admin_in_organisation?(current_organisation)
-            = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")
+          = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")
 
     .card.mt-2
       .card-body

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -34,17 +34,18 @@
       .card
         .card-body
           = render "bookable_by_text", motif: @motif
-          - if @motif.bookable_by_agents_and_prescripteurs?
-            = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn fr-btn--secondary", method: :post
-          - elsif @motif.bookable_by_invited_users?
-            .fr-btns-group.fr-btns-group--inline
-              = button_to "Ouvrir à tous les usagers", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
-              = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
-          - else
-            .fr-btns-group.fr-btns-group--inline
-              = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
-              - if current_organisation.rdv_insertion?
-                = button_to "Ouvrir aux usagers invités", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents_and_prescripteurs_and_invited_users), class: "fr-btn fr-btn--secondary", method: :post
+          - if policy(@motif, policy_class: Agent::MotifPolicy).edit?
+            - if @motif.bookable_by_agents_and_prescripteurs?
+              = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn fr-btn--secondary", method: :post
+            - elsif @motif.bookable_by_invited_users?
+              .fr-btns-group.fr-btns-group--inline
+                = button_to "Ouvrir à tous les usagers", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
+                = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
+            - else
+              .fr-btns-group.fr-btns-group--inline
+                = button_to "Ouvrir à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :everyone), class: "fr-btn", method: :post
+                - if current_organisation.rdv_insertion?
+                  = button_to "Ouvrir aux usagers invités", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents_and_prescripteurs_and_invited_users), class: "fr-btn fr-btn--secondary", method: :post
 
     - unless current_organisation.sectorized?
       - if @motif.bookable_by_everyone?
@@ -65,7 +66,8 @@
         .card-body
           .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
             h3.fr-h4 Options de réservation
-            = link_to "Modifier", edit_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
+            - if policy(@motif, policy_class: Agent::MotifPolicy).edit?
+              = link_to "Modifier", edit_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
 
           p.fr-my-2w
             | Les rendez-vous seront pris au moins <b>#{ min_max_delay_int_to_human(@motif.min_public_booking_delay) }</b> et au maximum <b>#{ min_max_delay_int_to_human(@motif.max_public_booking_delay) }</b> à l'avance.
@@ -83,7 +85,8 @@
         .card-body
           .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
             h2.fr-h4 Consignes pour les usagers
-            = link_to "Modifier", edit_instructions_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
+            - if policy(@motif, policy_class: Agent::MotifPolicy).edit_instructions?
+              = link_to "Modifier", edit_instructions_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
           = render "admin/motifs/restriction_for_rdv_recap", motif: @motif
           = render "admin/motifs/instruction_for_rdv_recap", motif: @motif
 
@@ -94,7 +97,8 @@
           .fr-btns-group.fr-btns-group--inline
             - if current_agent.territorial_admin_in?(current_territory)
               = link_to "Configuration des secteurs", admin_territory_sectors_path(current_territory), class: "fr-btn fr-btn--tertiary"
-            = link_to "Modifier", edit_sectorisation_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
+            - if policy(@motif, policy_class: Agent::MotifPolicy).edit_sectorisation?
+              = link_to "Modifier", edit_sectorisation_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
 
         div= @motif.human_attribute_value(:sectorisation_level)
         div.fr-text-mention--grey= @motif.human_attribute_value(:sectorisation_level, context: :hint)
@@ -104,7 +108,8 @@
         .card-body
           h3.fr-h4 Réservation en ligne
           p Ce motif est <b>ouvert</b> à la réservation en ligne : les usagers pourront prendre rendez-vous pour ce motif depuis le lien de réservation (sous réserve d’avoir une plage d’ouverture associée).
-          .fr-btns-group.fr-btns-group--inline
-            = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
-            - if current_organisation.rdv_insertion?
-              = button_to "Restreindre aux usagers invités", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents_and_prescripteurs_and_invited_users), class: "fr-btn fr-btn--secondary", method: :post
+          - if policy(@motif, policy_class: Agent::MotifPolicy).edit?
+            .fr-btns-group.fr-btns-group--inline
+              = button_to "Fermer à la réservation en ligne", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents), class: "fr-btn fr-btn--secondary", method: :post
+              - if current_organisation.rdv_insertion?
+                = button_to "Restreindre aux usagers invités", update_bookable_by_admin_organisation_online_booking_motif_path(current_organisation, @motif, bookable_by: :agents_and_prescripteurs_and_invited_users), class: "fr-btn fr-btn--secondary", method: :post

--- a/app/views/admin/organisations/online_bookings/not_configured.html.slim
+++ b/app/views/admin/organisations/online_bookings/not_configured.html.slim
@@ -1,0 +1,10 @@
+= render "admin/organisations/configurations/fil_ariane", current_page_title: "Réservation en ligne"
+
+- content_for :title do
+  | Réservation en ligne
+
+.fr-grid-row
+  .fr-col-12.fr-col-lg-10
+    .card.card-body
+      p La réservation en ligne n'est pas encore configurée pour cette organisation.
+      p Un administrateur de l'organisation peut activer cette fonctionnalité pour un ou plusieurs motifs.

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -48,7 +48,8 @@
   .card-body
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
       h2.fr-h4 Modes d'authentification
-      = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
+      - if policy(@organisation, policy_class: Agent::OrganisationPolicy).edit?
+        = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
     p
       |> Vos usagers peuvent se connecter avec
       ruby:
@@ -64,7 +65,8 @@
   .card-body
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
       h3.fr-h4 Motifs ouverts à la réservation en ligne
-      = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
+      - if policy(@organisation, policy_class: Agent::OrganisationPolicy).edit?
+        = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
     ul.list-unstyled.my-1
       - @open_motifs.each do |motif|
         li = render "motif_card", motif:
@@ -74,7 +76,8 @@
     .card-body
       .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
         h3.fr-h4 Motifs fermés à la réservation en ligne
-        = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
+        - if policy(@organisation, policy_class: Agent::OrganisationPolicy).edit?
+          = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
       ul.list-unstyled.my-1
         - @closed_motifs.each do |motif|
           li = render "motif_card", motif:

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -24,9 +24,7 @@ aside.left-side-menu-wrapper
       = render(DsfrComponent::SideMenuComponent.new(title: "Menu", html_attributes: {id: "menu"} )) do |menu|
         ruby:
           menu.with_item(title: safe_join([icon("fr-icon-calendar-event-line", class: "fr-icon--sm fr-mr-1w"), "Planning"]), path: admin_organisation_planning_agenda_path(current_organisation, **query_params), current_page: active_item == :menu_planning)
-        - if current_agent.admin_in_organisation?(current_organisation)
-          - menu.with_item(title: safe_join([icon("fr-icon-global-line", class: "fr-icon--sm fr-mr-1w"), "Réservation en ligne"]), path: admin_organisation_online_booking_path(current_organisation), current_page: active_item == :menu_online_booking)
-        ruby:
+          menu.with_item(title: safe_join([icon("fr-icon-global-line", class: "fr-icon--sm fr-mr-1w"), "Réservation en ligne"]), path: admin_organisation_online_booking_path(current_organisation), current_page: active_item == :menu_online_booking)
           menu.with_item(title: safe_join([icon("fr-icon-team-line", class: "fr-icon--sm fr-mr-1w"), "RDV collectifs"]), path: admin_organisation_rdvs_collectifs_path(current_organisation), current_page: active_item == :menu_rdv_collectifs)
           menu.with_item(title: safe_join([icon("fr-icon-group-line", class: "fr-icon--sm fr-mr-1w"), "Usagers"]), path: admin_organisation_users_path(current_organisation), current_page: active_item == :menu_users)
           menu.with_item(title: safe_join([icon("fr-icon-survey-line", class: "fr-icon--sm fr-mr-1w"), "Liste des RDV"]), path: admin_organisation_rdvs_path(current_organisation), current_page: active_item == :menu_liste_rdvs)

--- a/spec/features/agents/online_booking/agent_access_spec.rb
+++ b/spec/features/agents/online_booking/agent_access_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "Non-admin agents can view online booking without editing it" do
+  let!(:organisation) { create(:organisation) }
+  let!(:service) { create(:service) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], services: [service]) }
+  let!(:motif) { create(:motif, organisation: organisation, service: service, bookable_by: :everyone, collectif: false) }
+  let!(:other_service_motif) { create(:motif, organisation: organisation, service: create(:service), bookable_by: :everyone, collectif: false) }
+
+  before { login_as(agent, scope: :agent) }
+
+  it "affiche le menu Réservation en ligne" do
+    visit admin_organisation_planning_agenda_path(organisation)
+    expect(page).to have_link("Réservation en ligne", href: admin_organisation_online_booking_path(organisation))
+  end
+
+  it "permet de consulter les liens de réservation sans pouvoir modifier les paramètres" do
+    visit admin_organisation_online_booking_path(organisation)
+
+    expect(page).to have_content("Lien de réservation")
+    expect(page).to have_content(motif.name)
+    expect(page).not_to have_content(other_service_motif.name)
+    expect(page).not_to have_link("Modifier")
+
+    click_on motif.name
+
+    expect(page).to have_content("Lien de réservation direct")
+    expect(page).not_to have_link("Modifier")
+    expect(page).not_to have_button("Fermer à la réservation en ligne")
+  end
+
+  it "affiche un message quand aucun motif n'est encore ouvert, sans proposer le formulaire de configuration" do
+    motif.update!(bookable_by: :agents)
+    other_service_motif.update!(bookable_by: :agents)
+
+    visit admin_organisation_online_booking_path(organisation)
+
+    expect(page).to have_content("La réservation en ligne n'est pas encore configurée")
+    expect(page).not_to have_content("Pour quels motifs souhaitez-vous ouvrir la prise de rendez-vous en ligne ?")
+  end
+
+  it "refuse l'accès direct aux pages de modification" do
+    visit edit_admin_organisation_online_booking_path(organisation)
+    expect(page).not_to have_content("Pour quels motifs souhaitez-vous ouvrir la prise de rendez-vous en ligne ?")
+
+    visit edit_user_type_admin_organisation_online_booking_path(organisation)
+    expect(page).not_to have_content("Modes d'authentification")
+
+    visit edit_admin_organisation_online_booking_motif_path(organisation, motif)
+    expect(page).not_to have_content("Options de réservation")
+  end
+end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6628.osc-secnum-fr1.scalingo.io/)

# Contexte

Le menu « Réservation en ligne » n'était visible et accessible que pour les agents ayant un rôle admin sur l'organisation. Les agents simples n'avaient donc aucun moyen de consulter le lien de prise de rendez-vous en ligne de leur organisation, ni les liens spécifiques aux motifs.

# Solution

- Le menu « Réservation en ligne » est désormais affiché à tous les agents de l'organisation, et plus seulement aux admins.
- Sur les pages de réservation en ligne (organisation et motif), les actions de modification (boutons « Modifier », ouverture/fermeture d'un motif à la réservation, changement des modes d'authentification, etc.) sont masquées pour les agents non-admin.
- La liste des motifs affichés reste filtrée selon les droits de l'agent (motifs de son service, ou sans service, comme partout ailleurs dans l'application) via `Motif.available_motifs_for_organisation_and_agent`.
- Lorsque aucun motif n'est encore ouvert à la réservation en ligne, seuls les admins voient le formulaire de configuration initiale ; les autres agents voient désormais un message indiquant que la réservation en ligne n'est pas encore configurée.

