### PR TITLE
Scoper les motifs affichés dans la bannière d’onboarding

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -14,7 +14,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
       @open_motifs = @motifs.bookable_by_everyone
       @closed_motifs = @motifs.where.not(bookable_by: :everyone)
 
-      @banner = OnlineBookingOnboardingBanner.new(@motifs)
+      @banner = OnlineBookingOnboardingBanner.new(current_organisation) if current_agent.admin_in_organisation?(current_organisation)
     end
   end
 

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -14,7 +14,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
       @open_motifs = @motifs.bookable_by_everyone
       @closed_motifs = @motifs.where.not(bookable_by: :everyone)
 
-      @banner = OnlineBookingOnboardingBanner.new(current_organisation)
+      @banner = OnlineBookingOnboardingBanner.new(@motifs)
     end
   end
 

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -107,10 +107,8 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   private
 
   def update_online_booking_banner_display
-    if session["OnlineBookingMotifsForm:completed"]
-      motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
-        .available_motifs_for_organisation_and_agent(current_organisation, current_agent)
-      banner = OnlineBookingOnboardingBanner.new(motifs)
+    if session["OnlineBookingMotifsForm:completed"] && current_agent.admin_in_organisation?(current_organisation)
+      banner = OnlineBookingOnboardingBanner.new(current_organisation)
       # S'il n'y a plus besoin de la bannière, on arrête de l'afficher
       unless banner.availabilities_needed?
         session.delete("OnlineBookingMotifsForm:completed")

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -1,5 +1,6 @@
 class Admin::Planning::PlageOuverturesController < AgentAuthController
   include Admin::Planning::PlanningConcern
+
   respond_to :html, :json
 
   before_action :set_plage_ouverture, only: %i[show edit update destroy]
@@ -107,7 +108,9 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
 
   def update_online_booking_banner_display
     if session["OnlineBookingMotifsForm:completed"]
-      banner = OnlineBookingOnboardingBanner.new(current_organisation)
+      motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
+        .available_motifs_for_organisation_and_agent(current_organisation, current_agent)
+      banner = OnlineBookingOnboardingBanner.new(motifs)
       # S'il n'y a plus besoin de la bannière, on arrête de l'afficher
       unless banner.availabilities_needed?
         session.delete("OnlineBookingMotifsForm:completed")

--- a/app/form_models/admin/online_booking_motifs_form.rb
+++ b/app/form_models/admin/online_booking_motifs_form.rb
@@ -47,7 +47,7 @@ class Admin::OnlineBookingMotifsForm
   end
 
   def prepare_flash_and_session_for_activation(flash, session)
-    banner = OnlineBookingOnboardingBanner.new(motifs)
+    banner = OnlineBookingOnboardingBanner.new(@organisation)
 
     if banner.availabilities_needed?
       # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre

--- a/app/form_models/admin/online_booking_motifs_form.rb
+++ b/app/form_models/admin/online_booking_motifs_form.rb
@@ -47,14 +47,14 @@ class Admin::OnlineBookingMotifsForm
   end
 
   def prepare_flash_and_session_for_activation(flash, session)
-    banner = OnlineBookingOnboardingBanner.new(@organisation)
+    banner = OnlineBookingOnboardingBanner.new(motifs)
 
     if banner.availabilities_needed?
       # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre
       session["OnlineBookingMotifsForm:completed"] = true
     else
       motif_names = motifs.bookable_by_everyone.pluck(:name)
-      flash[:success] = if motif_names.count == 1
+      flash[:success] = if motif_names.one?
                           "Le motif #{motif_names.first} est ouvert pour la réservation en ligne."
                         else
                           "Les motifs #{motif_names.to_sentence} sont ouverts pour la réservation en ligne."

--- a/app/presenters/online_booking_onboarding_banner.rb
+++ b/app/presenters/online_booking_onboarding_banner.rb
@@ -1,9 +1,6 @@
 class OnlineBookingOnboardingBanner
-  # `motifs` doit déjà être scopé selon ce que l'agent courant a le droit de voir
-  # (ex : Agent::MotifPolicy::Scope), pour ne pas inviter l'agent à agir sur des motifs
-  # appartenant à des services auxquels il n'a pas accès.
-  def initialize(motifs)
-    @motifs = motifs
+  def initialize(organisation)
+    @organisation = organisation
   end
 
   def availabilities_needed?
@@ -11,7 +8,7 @@ class OnlineBookingOnboardingBanner
   end
 
   def motifs_with_missing_availabilities
-    @motifs_with_missing_availabilities ||= @motifs.active.bookable_by_everyone.select do |motif|
+    @motifs_with_missing_availabilities ||= @organisation.motifs.active.bookable_by_everyone.select do |motif|
       motif.upcoming_availabilities.none?
     end
   end

--- a/app/presenters/online_booking_onboarding_banner.rb
+++ b/app/presenters/online_booking_onboarding_banner.rb
@@ -1,6 +1,9 @@
 class OnlineBookingOnboardingBanner
-  def initialize(organisation)
-    @organisation = organisation
+  # `motifs` doit déjà être scopé selon ce que l'agent courant a le droit de voir
+  # (ex : Agent::MotifPolicy::Scope), pour ne pas inviter l'agent à agir sur des motifs
+  # appartenant à des services auxquels il n'a pas accès.
+  def initialize(motifs)
+    @motifs = motifs
   end
 
   def availabilities_needed?
@@ -8,7 +11,7 @@ class OnlineBookingOnboardingBanner
   end
 
   def motifs_with_missing_availabilities
-    @motifs_with_missing_availabilities ||= @organisation.motifs.active.bookable_by_everyone.select do |motif|
+    @motifs_with_missing_availabilities ||= @motifs.active.bookable_by_everyone.select do |motif|
       motif.upcoming_availabilities.none?
     end
   end

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -4,7 +4,7 @@
   | Réservation en ligne
 
 - content_for :onboarding_banner do
-  - if @banner.availabilities_needed? && session["OnlineBookingMotifsForm:completed"]
+  - if @banner&.availabilities_needed? && session["OnlineBookingMotifsForm:completed"]
     .fr-callout.fr-pb-2w
       h2.fr-h6 🎉 Vous y êtes presque !
 


### PR DESCRIPTION
# Contexte

Nous allons bientôt afficher le menu réservation en ligne à tous les agents. Il faut donc scoper les motifs affichés dans le bandeau d’onboarding pour éviter qu’on demande à un agent d’ouvrir des plages d’ouvertures pour un motif auquel il n’a pas accès.
Je propose donc cette PR préliminaire à ma PR #6628 
