### PR TITLE
Indiquer aux usagers de se connecter avec leur SSO 

### DIFF
--- a/app/form_models/users/login_code_request_form.rb
+++ b/app/form_models/users/login_code_request_form.rb
@@ -27,7 +27,7 @@ module Users
       sso_user = User.fiches_for_email(email).with_sso.first
       error =
         if sso_user
-          "Ce compte usager se connecte avec #{sso_user.sso_provider_name}. Merci d’utiliser ce moyen de connexion."
+          "Ce compte usager a été créé avec #{sso_user.sso_provider_name}. Merci d’utiliser ce moyen de connexion."
         elsif Agent.exists?(email:)
           <<~ERROR
             Aucun compte usager n’existe pour cet email.

--- a/app/form_models/users/login_code_request_form.rb
+++ b/app/form_models/users/login_code_request_form.rb
@@ -24,8 +24,11 @@ module Users
     def validate_user_exists_or_suggest_agent
       return true if User.loginable_by_code_for_email(email).any?
 
+      sso_user = User.fiches_for_email(email).with_sso.first
       error =
-        if Agent.exists?(email:)
+        if sso_user
+          "Ce compte usager se connecte avec #{sso_user.sso_provider_name}. Merci d’utiliser ce moyen de connexion."
+        elsif Agent.exists?(email:)
           <<~ERROR
             Aucun compte usager n’existe pour cet email.
             Si vous souhaitez vous connecter en tant qu’agent, veuillez vous rendre sur la page de connexion agent.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,7 @@ class User < ApplicationRecord
   scope :relative, -> { where.not(responsible_id: nil) }
   scope :fiches_for_email, ->(email) { where(email:) }
   scope :without_sso, -> { where(franceconnect_openid_sub: nil, pro_connect_openid_sub: nil) }
+  scope :with_sso, -> { where.not(franceconnect_openid_sub: nil).or(where.not(pro_connect_openid_sub: nil)) }
   scope :loginable_by_code_for_email, ->(email) { fiches_for_email(email).without_sso }
   scope :loginable_by_code_for_email_in_territory_or_without_territory, lambda { |email, territory_id:|
     loginable_by_code_for_email(email)
@@ -260,6 +261,12 @@ class User < ApplicationRecord
 
   def connected_with_sso?
     (franceconnect_openid_sub || pro_connect_openid_sub).present?
+  end
+
+  def sso_provider_name
+    return "FranceConnect" if franceconnect_openid_sub.present?
+
+    "ProConnect" if pro_connect_openid_sub.present?
   end
 
   def already_logged_in?

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       fill_in "Adresse email", with: "fc@lolmail.fr"
       expect { click_on "Recevoir un code de connexion" }.not_to change(LoginCode, :count)
       expect(page).not_to have_content("code à 6 chiffres")
-      expect(page).to have_content("Ce compte usager se connecte avec FranceConnect. Merci d’utiliser ce moyen de connexion.")
+      expect(page).to have_content("Ce compte usager a été créé avec FranceConnect. Merci d’utiliser ce moyen de connexion.")
     end
   end
 

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       fill_in "Adresse email", with: "fc@lolmail.fr"
       expect { click_on "Recevoir un code de connexion" }.not_to change(LoginCode, :count)
       expect(page).not_to have_content("code à 6 chiffres")
-      expect(page).to have_content("Aucun compte usager n’existe pour cet email")
+      expect(page).to have_content("Ce compte usager se connecte avec FranceConnect. Merci d’utiliser ce moyen de connexion.")
     end
   end
 

--- a/spec/form_models/users/login_code_request_form_spec.rb
+++ b/spec/form_models/users/login_code_request_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
     it "le form est invalide et précise qu'il faut utiliser FranceConnect" do
       form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
       expect(form).to be_invalid
-      expect(form.errors[:base]).to include("Ce compte usager se connecte avec FranceConnect. Merci d’utiliser ce moyen de connexion.")
+      expect(form.errors[:base]).to include("Ce compte usager a été créé avec FranceConnect. Merci d’utiliser ce moyen de connexion.")
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
     it "le form est invalide et précise qu'il faut utiliser ProConnect" do
       form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
       expect(form).to be_invalid
-      expect(form.errors[:base]).to include("Ce compte usager se connecte avec ProConnect. Merci d’utiliser ce moyen de connexion.")
+      expect(form.errors[:base]).to include("Ce compte usager a été créé avec ProConnect. Merci d’utiliser ce moyen de connexion.")
     end
   end
 

--- a/spec/form_models/users/login_code_request_form_spec.rb
+++ b/spec/form_models/users/login_code_request_form_spec.rb
@@ -17,6 +17,36 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
     end
   end
 
+  context "l’usager existe mais s’est créé via FranceConnect" do
+    let!(:user) { create(:user, :using_france_connect, email: "us@ger.fr") }
+
+    it "le form est invalide et précise qu'il faut utiliser FranceConnect" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).to be_invalid
+      expect(form.errors[:base]).to include("Ce compte usager se connecte avec FranceConnect. Merci d’utiliser ce moyen de connexion.")
+    end
+  end
+
+  context "l’usager existe mais s’est créé via ProConnect" do
+    let!(:user) { create(:user, :using_pro_connect, email: "us@ger.fr") }
+
+    it "le form est invalide et précise qu'il faut utiliser ProConnect" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).to be_invalid
+      expect(form.errors[:base]).to include("Ce compte usager se connecte avec ProConnect. Merci d’utiliser ce moyen de connexion.")
+    end
+  end
+
+  context "l'usager n'existe pas mais un agent existe avec cet email" do
+    let!(:agent) { create(:agent, email: "us@ger.fr") }
+
+    it "le form est invalide et suggère la page de connexion agent" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).to be_invalid
+      expect(form.errors[:base].join).to include("page de connexion agent")
+    end
+  end
+
   context "l'usager n'existe pas, avec behaviour :upsert_user" do
     it "le form est valide et la sauvegarde créé le login_code" do
       form = described_class.new(LoginCode.new(email: "new@user.fr", first_name: "Nina", last_name: "Personne", domain_id: "RDV_SERVICE_PUBLIC"), behaviour: "upsert_user")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,37 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe ".with_sso" do
+    let!(:user_normal)          { create(:user, email: "test@example.fr") }
+    let!(:user_france_connect)  { create(:user, email: "test@example.fr", franceconnect_openid_sub: "abc123") }
+    let!(:user_pro_connect)     { create(:user, email: "test@example.fr", pro_connect_openid_sub: "def456") }
+
+    it "ne retourne que les fiches connectées via SSO (FranceConnect ou ProConnect)" do
+      expect(described_class.with_sso).to contain_exactly(user_france_connect, user_pro_connect)
+    end
+
+    it "exclut les fiches non connectées via SSO" do
+      expect(described_class.with_sso).not_to include(user_normal)
+    end
+  end
+
+  describe "#sso_provider_name" do
+    it "retourne FranceConnect pour un compte connecté via FranceConnect" do
+      user = build(:user, franceconnect_openid_sub: "abc123")
+      expect(user.sso_provider_name).to eq("FranceConnect")
+    end
+
+    it "retourne ProConnect pour un compte connecté via ProConnect" do
+      user = build(:user, pro_connect_openid_sub: "def456")
+      expect(user.sso_provider_name).to eq("ProConnect")
+    end
+
+    it "retourne nil pour un compte non connecté via SSO" do
+      user = build(:user)
+      expect(user.sso_provider_name).to be_nil
+    end
+  end
+
   describe ".loginable_by_code_for_email_in_territory_or_without_territory" do
     let!(:territory_1)    { create(:territory) }
     let!(:territory_2)    { create(:territory) }


### PR DESCRIPTION
Fixes #6320 . Cette PR est basée sur un travail préliminaire via LLM  dans https://github.com/botadrientronics/rdv-service-public/pull/6

# Contexte

Quand une usagere a créé son compte via FC ou PC, puis tente ensuite de se connecter via le login par code à 6 chiffres, le message d'erreur affiché est erroné :

> Aucun compte usager n'existe pour cet email

## Avant / après

| Avant | Après |
|-|-|
| <img width="307" height="676" alt="image" src="https://github.com/user-attachments/assets/7a2f8b14-2bef-40b1-85fb-595f554054f0" />| <img width="307" height="676" alt="image" src="https://github.com/user-attachments/assets/f2bfd8c7-e774-4eea-b78c-28eee6118845" /> |

## Changements

- Ajoute un scope `User.with_sso`, complémentaire de `User.without_sso` existant
- Ajoute `User#sso_provider_name` 
- Dans `Users::LoginCodeRequestForm#validate_user_exists_or_suggest_agent`, vérifie ce cas en priorité et affiche un message explicite nommant FranceConnect ou ProConnect selon le compte trouvé, avant de retomber sur les cas existants (agent avec le même email, ou vraiment aucun compte).
- Ajoute des tests pour les deux nouveaux cas (FranceConnect, ProConnect) dans `login_code_request_form_spec.rb`, un test direct pour `sso_provider_name` et pour le scope `with_sso` dans `user_spec.rb`. 
- [bonus] ajoute un test manquant pour le cas "agent existe avec cet email"

# Review app

Pas de review app car FranceConnect c'est plus facile à tester en local