### PR TITLE
Suppression de l’utilisation des button groups Bootstrap

### DIFF
--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -16,7 +16,7 @@
 @import "bootstrap/scss/buttons";
 @import "bootstrap/scss/transitions";
 @import "bootstrap/scss/dropdown";
-@import "bootstrap/scss/button-group";
+//@import "bootstrap/scss/button-group";
 @import "bootstrap/scss/input-group";
 @import "bootstrap/scss/custom-forms";
 @import "bootstrap/scss/nav";

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -4,8 +4,7 @@
 - needs_collectif_motif = current_organisation.motifs.collectif.active.none?
 - content_for :right_of_page_title do
   - unless needs_collectif_motif
-    .btn-group
-      = link_to "Nouveau RDV collectif", admin_organisation_rdvs_collectif_motif_selections_path(current_organisation), class: "fr-btn"
+    = link_to "Nouveau RDV collectif", admin_organisation_rdvs_collectif_motif_selections_path(current_organisation), class: "fr-btn"
 
 .card
   - unless needs_collectif_motif

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -50,5 +50,4 @@
           = f.dsfr_number_field :max_participants_count, label: Rdv.human_attribute_name(:max_participants_count), min: 1
 
           .d-flex.justify-content-end
-            .btn-group
-              = f.submit t("helpers.submit.submit"), class: "fr-btn"
+            = f.submit t("helpers.submit.submit"), class: "fr-btn"

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -2,8 +2,8 @@
   | Usagers
 
 - content_for :right_of_page_title do
-  .btn-group
-    = link_to "Fusionner deux usagers", new_admin_organisation_merge_users_path(current_organisation), class: "fr-btn fr-btn--secondary mr-1"
+  .fr-btns-group.fr-btns-group--inline
+    = link_to "Fusionner deux usagers", new_admin_organisation_merge_users_path(current_organisation), class: "fr-btn fr-btn--secondary"
     = link_to "Ajouter un usager", new_admin_organisation_user_path(current_organisation), class: "fr-btn"
 
 .card[class="#{"fr-mt-6w" if @search_needed}"]


### PR DESCRIPTION
# Contexte

Je reprends les travaux de migration Bootstrap → DSFR.

# Solution

J’ai remplacé par un btn group DSFR où c’était nécessaire sinon j’ai simplement retiré les btn-group.