### PR TITLE
Import de Boostrap file by file dans agent config

### DIFF
--- a/app/javascript/stylesheets/application_agent_config.scss
+++ b/app/javascript/stylesheets/application_agent_config.scss
@@ -56,8 +56,8 @@
 @import "bootstrap/scss/utilities/text";
 //@import "bootstrap/scss/utilities/visibility";
 
-//@import "select2/dist/css/select2";
-//@import "select2-bootstrap4-theme/dist/select2-bootstrap4.min";
+@import "select2/dist/css/select2";
+@import "select2-bootstrap4-theme/dist/select2-bootstrap4.min";
 
 @import "vendor/proconnect_button_dsfr";
 
@@ -70,7 +70,7 @@
 @import "./components/utilities_dsfr";
 @import "./components/autocomplete";
 @import "./components/rdv_solidarites_instance_name";
-//@import "./components/select2";
+@import "./components/select2";
 
 // Structure
 @import "./structure/general";

--- a/app/javascript/stylesheets/application_agent_config.scss
+++ b/app/javascript/stylesheets/application_agent_config.scss
@@ -3,9 +3,61 @@
 @import "bootstrap/scss/mixins";
 @import "./_variables";
 
-@import "bootstrap/scss/bootstrap";
-@import "select2/dist/css/select2";
-@import "select2-bootstrap4-theme/dist/select2-bootstrap4.min";
+// import bootstrap file by file so we can remove unwanted rules component by component
+// cf https://github.com/twbs/bootstrap/blob/v4.3.1/scss/bootstrap.scss
+@import "bootstrap/scss/root";
+@import "bootstrap/scss/reboot";
+@import "bootstrap/scss/type";
+@import "bootstrap/scss/images";
+// @import "bootstrap/scss/code";
+@import "bootstrap/scss/grid";
+@import "bootstrap/scss/tables";
+@import "bootstrap/scss/forms";
+@import "bootstrap/scss/buttons";
+//@import "bootstrap/scss/transitions";
+//@import "bootstrap/scss/dropdown";
+//@import "bootstrap/scss/button-group";
+@import "bootstrap/scss/input-group";
+//@import "bootstrap/scss/custom-forms";
+//@import "bootstrap/scss/nav";
+//@import "bootstrap/scss/navbar";
+@import "bootstrap/scss/card";
+//@import "bootstrap/scss/breadcrumb";
+//@import "bootstrap/scss/pagination";
+//@import "bootstrap/scss/badge";
+//@import "bootstrap/scss/jumbotron";
+//@import "bootstrap/scss/alert";
+//@import "bootstrap/scss/progress";
+//@import "bootstrap/scss/media";
+@import "bootstrap/scss/list-group";
+//@import "bootstrap/scss/close";
+//@import "bootstrap/scss/toasts";
+//@import "bootstrap/scss/modal";
+//@import "bootstrap/scss/tooltip";
+//@import "bootstrap/scss/popover";
+//@import "bootstrap/scss/carousel";
+//@import "bootstrap/scss/spinners";
+//@import "bootstrap/scss/utilities/align";
+//@import "bootstrap/scss/utilities/background";
+//@import "bootstrap/scss/utilities/borders";
+//@import "bootstrap/scss/utilities/clearfix";
+@import "bootstrap/scss/utilities/display";
+//@import "bootstrap/scss/utilities/embed";
+@import "bootstrap/scss/utilities/flex";
+@import "bootstrap/scss/utilities/float";
+//@import "bootstrap/scss/utilities/interactions";
+//@import "bootstrap/scss/utilities/overflow";
+//@import "bootstrap/scss/utilities/position";
+//@import "bootstrap/scss/utilities/screenreaders";
+//@import "bootstrap/scss/utilities/shadows";
+@import "bootstrap/scss/utilities/sizing";
+@import "bootstrap/scss/utilities/spacing";
+//@import "bootstrap/scss/utilities/stretched-link";
+@import "bootstrap/scss/utilities/text";
+//@import "bootstrap/scss/utilities/visibility";
+
+//@import "select2/dist/css/select2";
+//@import "select2-bootstrap4-theme/dist/select2-bootstrap4.min";
 
 @import "vendor/proconnect_button_dsfr";
 
@@ -18,7 +70,7 @@
 @import "./components/utilities_dsfr";
 @import "./components/autocomplete";
 @import "./components/rdv_solidarites_instance_name";
-@import "./components/select2";
+//@import "./components/select2";
 
 // Structure
 @import "./structure/general";


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6635.osc-secnum-fr1.scalingo.io/)

# Contexte

Pour suivre l’avancée du remplacement des composants Boostrap par des composants DSFR (et pour alléger les assets), je propose d’appliquer dans application_agent_config.scss la même stratégie que dans les deux autres application.scss

