### PR TITLE
Correction de l’affichage des événements parcours RDV Plan

### DIFF
--- a/app/javascript/stylesheets/components/_fullcalendar_theme.scss
+++ b/app/javascript/stylesheets/components/_fullcalendar_theme.scss
@@ -72,6 +72,14 @@
   max-width: 100%;
 }
 
+// Le DSFR souligne les liens via background-image (plutôt que text-decoration), ce qui casse
+// le rendu des évènements du calendrier. On neutralise ce soulignement pour les liens internes
+// au calendrier, indépendamment du bundle CSS chargé.
+// .rdv-fc-event-waiting est exclu car il utilise lui-même background-image pour ses hachures.
+.fc-classic-n5m a[href]:not(.rdv-fc-event-waiting) {
+  background-image: none;
+}
+
 // Vue mois et planning : gris subtil DSFR
 .fc-classic-n5m a[href]:hover {
   background-color: var(--background-contrast-grey) !important;


### PR DESCRIPTION
# Contexte

Nous avons des overrides du CSS du DSFR notamment pour enlever le soulignement des liens dans certains cas. 
Dans le parcours RDV Plan, on ne charge pas tout le CSS côté agent, ce qui génère une incohérence visuelle dans le calendrier.

# Solution

Je mets donc l’override dans notre theme fullcalendar.

## Captures d'écran

Avant | Après
:- | -:
<img width="1280" height="818" alt="image" src="https://github.com/user-attachments/assets/c1f432bc-7390-4c3c-bce5-825ca7a86fcd" /> | <img width="1282" height="818" alt="image" src="https://github.com/user-attachments/assets/34ffaa24-4a1e-4699-b360-d739005452f3" />
