### PR TITLE
Rdv#show : ne pas cacher les options avancées dans un accordéon

### DIFF
--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -81,38 +81,35 @@
             = @motif.custom_cancel_warning_message
 
     .card.mt-2
-      .rdv-accordion-card.fr-accordion
-        h2.fr-accordion__title
-          button.fr-h5.fr-accordion__btn aria-expanded="false" aria-controls="options-avancees"
-            | Options avancées
-        .fr-collapse id="options-avancees"
-          .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-            div
-              b= @motif.human_attribute_value(:visibility_type, context: :html)
+      .card-body
+        .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+          h2.fr-h5 Options avancées
 
-              .fr-text-mention--grey
-                = @motif.human_attribute_value(:visibility_type, context: :hint)
-                - if current_organisation.rdv_insertion?
-                  br
-                  span= @motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
+          - if !@motif.archived? && @motif_policy.edit?
+            = link_to t("admin.motifs.actions.edit"), edit_advanced_options_admin_organisation_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
 
-              = motif_attribute_row \
-                Motif.human_attribute_name(:follow_up_short), \
-                motif_option_activated(@motif, :follow_up), \
-                hint: Motif.human_attribute_name(:follow_up_hint)
+        b= @motif.human_attribute_value(:visibility_type, context: :html)
 
-              = motif_attribute_row \
-                Motif.human_attribute_name(:for_secretariat_short), \
-                motif_option_activated(@motif, :for_secretariat), \
-                hint: Motif.human_attribute_name(:for_secretariat_hint)
+        .fr-text-mention--grey
+          = @motif.human_attribute_value(:visibility_type, context: :hint)
+          - if current_organisation.rdv_insertion?
+            br
+            span= @motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
 
-              = motif_attribute_row \
-                "Ouverture aux prescripteurs", \
-                motif_option_activated(@motif, :prescription), \
-                hint: sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.everyone"))
+        = motif_attribute_row \
+          Motif.human_attribute_name(:follow_up_short), \
+          motif_option_activated(@motif, :follow_up), \
+          hint: Motif.human_attribute_name(:follow_up_hint)
 
-            - if !@motif.archived? && @motif_policy.edit?
-              = link_to t("admin.motifs.actions.edit"), edit_advanced_options_admin_organisation_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
+        = motif_attribute_row \
+          Motif.human_attribute_name(:for_secretariat_short), \
+          motif_option_activated(@motif, :for_secretariat), \
+          hint: Motif.human_attribute_name(:for_secretariat_hint)
+
+        = motif_attribute_row \
+          "Ouverture aux prescripteurs", \
+          motif_option_activated(@motif, :prescription), \
+          hint: sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.everyone"))
 
     - if @motif_policy.edit? || @motif_policy.destroy?
       .card.mt-2

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -78,7 +78,7 @@
             i.fr-text-mention--grey Pas d'instructions à afficher quand l'usager annule le rendez-vous
         - else
           .fr-highlight.fr-mb-2w
-             = @motif.custom_cancel_warning_message
+            = @motif.custom_cancel_warning_message
 
     .card.mt-2
       .rdv-accordion-card.fr-accordion


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6641.osc-secnum-fr1.scalingo.io/)

Vu avec @mekaidmekaid : il y a trop d'accordéons sur cette page donc on déplie toujours les options avancées.

## Avant

### État initial

<img width="1574" height="142" alt="image" src="https://github.com/user-attachments/assets/868016c0-775b-4a0e-9448-a39d3346858f" />

### Après dépliage

<img width="1570" height="557" alt="image" src="https://github.com/user-attachments/assets/4ac056f0-3a2f-4966-821f-f944f615ad8c" />

## Après

<img width="1574" height="486" alt="image" src="https://github.com/user-attachments/assets/69413c06-f35c-4f85-affd-8ac6265cafbe" />

# Maquette fournie par @mekaidmekaid 

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/d80970a0-333e-45e3-b470-71dcfa87795e" />

