### PR TITLE
Aider les agents à trouver le nouveau menu de réservation en ligne

### DIFF
--- a/app/views/admin/motifs/edit.html.slim
+++ b/app/views/admin/motifs/edit.html.slim
@@ -11,6 +11,12 @@
 
 .row
   .col-md-12
+    / Le 25/8/2026 est la date de mise en ligne du changement d'interface.
+    - if current_agent.created_at < Date.new(2026, 8, 25)
+      p.fr-hint-text.fr-text--sm
+        = icon("fr-icon-information-line", class:"fr-mr-1w" )
+        | La gestion de la réservation en ligne se fait maintenant depuis la page de détails du motif ou depuis le menu de gauche.
+
     = form_for @motif, url: admin_organisation_motif_path, builder: Dsfr::FormBuilder, html: { "data-controller": "motif-form" } do |f|
       = render "model_errors", model: @motif, f: f
       = render "admin/motifs/form", motif: @motif, f: f, rdvi_mode: current_organisation.rdv_insertion?

--- a/app/views/admin/motifs/edit.html.slim
+++ b/app/views/admin/motifs/edit.html.slim
@@ -12,7 +12,7 @@
 .row
   .col-md-12
     / Le 25/8/2026 est la date de mise en ligne du changement d'interface.
-    - if current_agent.created_at < Date.new(2026, 8, 25)
+    - if current_agent.created_at < Date.new(2026, 8, 25) && Time.zone.now < Date.new(2026, 11, 25)
       p.fr-hint-text.fr-text--sm
         = icon("fr-icon-information-line", class:"fr-mr-1w" )
         | La gestion de la réservation en ligne se fait maintenant depuis la page de détails du motif ou depuis le menu de gauche.


### PR DESCRIPTION
<img width="1034" height="358" alt="Screenshot 2026-08-26 at 17 04 29" src="https://github.com/user-attachments/assets/eb59bb39-6496-48cd-9123-6614064bc199" />

Suite à https://github.com/betagouv/rdv-service-public/pull/6611, plusieurs agents ne retrouvent pas comment modifier la prise de rendez-vous en ligne. On ajoute un petit indice pour les aider à retrouver ce menu et limiter les tickets au support.