### PR TITLE
Afficher les options de secto pour les motifs ouverts aux prescripteurs

### DIFF
--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -87,7 +87,7 @@
           = render "admin/motifs/restriction_for_rdv_recap", motif: @motif
           = render "admin/motifs/instruction_for_rdv_recap", motif: @motif
 
-    - if current_territory.sectors.any? && @motif.bookable_by_everyone_or_bookable_by_invited_users?
+    - if current_territory.sectors.any? && @motif.bookable_outside_of_organisation?
       .card.card-body
         .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
           h2.fr-h4 Sectorisation


### PR DESCRIPTION
Petite demande d'Eva de RDV Insertion : il y a des cas où la sectorisation est utilisée pour des motifs ouverts uniquement aux prescripteurs, donc ça leur serait utile de voir ce menu.