### PR TITLE
Amélioration formulaire recherche agents

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -5,7 +5,7 @@ class Admin::AgentsController < AgentAuthController
   helper_method :agents_search_params
 
   def index
-    @agents_search_form = Admin::AgentsSearchForm.new(current_organisation:, admin_only: search_params[:admin_only] == "1", query: search_params[:query])
+    @agents_search_form = Admin::AgentsSearchForm.new(current_organisation:, query: params.dig(:search, :query), role: params.dig(:search, :role))
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
     @agents = @agents_search_form.filter_agents(@agents)
     @agents = @agents.includes(:services, :roles, :organisations)
@@ -109,10 +109,6 @@ class Admin::AgentsController < AgentAuthController
     @roles = access_levels_collection
 
     render :edit
-  end
-
-  def search_params
-    (params.permit(search: %i[query admin_only]) || {})[:search] || {}
   end
 
   def access_levels_collection

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -118,7 +118,7 @@ class Admin::AgentsController < AgentAuthController
   end
 
   def index_params
-    @index_params ||= params.permit(:term, :intervenant_term)
+    @index_params ||= params.permit(:term)
   end
 
   def access_levels_collection

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -5,19 +5,12 @@ class Admin::AgentsController < AgentAuthController
   helper_method :agents_search_params
 
   def index
+    @agents_search_form = Admin::AgentsSearchForm.new(current_organisation:, admin_only: search_params[:admin_only] == "1", query: search_params[:query])
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
-
-    @agents = @agents.joins(:organisations).where(organisations: { id: current_organisation.id })
-    @agents = if agents_search_params[:query].present?
-                @agents.search_by_text(agents_search_params[:query])
-              else
-                @agents.order(Arel.sql("(invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL) DESC")).ordered_by_last_name
-              end
-
-    @display_services = current_territory.services.any? || current_organisation.agents.joins(:agent_services).any?
-
+    @agents = @agents_search_form.filter_agents(@agents)
     @agents = @agents.includes(:services, :roles, :organisations)
     @agents = @agents.page(page_number)
+    @display_services = current_territory.services.any? || current_organisation.agents.joins(:agent_services).any?
   end
 
   def new
@@ -118,12 +111,8 @@ class Admin::AgentsController < AgentAuthController
     render :edit
   end
 
-  def index_params
-    @index_params ||= params.permit(agents_search: [:query])
-  end
-
-  def agents_search_params
-    index_params[:agents_search] || {}
+  def search_params
+    (params.permit(search: %i[query admin_only]) || {})[:search] || {}
   end
 
   def access_levels_collection

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -2,13 +2,14 @@ class Admin::AgentsController < AgentAuthController
   respond_to :html
 
   before_action :ensure_agent_is_admin, except: :index
+  helper_method :agents_search_params
 
   def index
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
 
     @agents = @agents.joins(:organisations).where(organisations: { id: current_organisation.id })
-    @agents = if index_params[:term].present?
-                @agents.search_by_text(index_params[:term])
+    @agents = if agents_search_params[:query].present?
+                @agents.search_by_text(agents_search_params[:query])
               else
                 @agents.order(Arel.sql("(invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL) DESC")).ordered_by_last_name
               end
@@ -118,7 +119,11 @@ class Admin::AgentsController < AgentAuthController
   end
 
   def index_params
-    @index_params ||= params.permit(:term)
+    @index_params ||= params.permit(agents_search: [:query])
+  end
+
+  def agents_search_params
+    index_params[:agents_search] || {}
   end
 
   def access_levels_collection

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -6,11 +6,12 @@ class Admin::AgentsController < AgentAuthController
 
   def index
     @agents_search_form = Admin::AgentsSearchForm.new(current_organisation:, query: params.dig(:search, :query), role: params.dig(:search, :role))
-    @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
-    @agents = @agents_search_form.filter_agents(@agents)
+    agents_scope = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
+    @agents = @agents_search_form.filter_agents(agents_scope)
     @agents = @agents.includes(:services, :roles, :organisations)
     @agents = @agents.page(page_number)
     @display_services = current_territory.services.any? || current_organisation.agents.joins(:agent_services).any?
+    @agents_filtered_out_count = @agents_search_form.organisation_scope(agents_scope).count - @agents.total_count
   end
 
   def new

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -2,7 +2,6 @@ class Admin::AgentsController < AgentAuthController
   respond_to :html
 
   before_action :ensure_agent_is_admin, except: :index
-  helper_method :agents_search_params
 
   def index
     @agents_search_form = Admin::AgentsSearchForm.new(current_organisation:, query: params.dig(:search, :query), role: params.dig(:search, :role))
@@ -11,7 +10,6 @@ class Admin::AgentsController < AgentAuthController
     @agents = @agents.includes(:services, :roles, :organisations)
     @agents = @agents.page(page_number)
     @display_services = current_territory.services.any? || current_organisation.agents.joins(:agent_services).any?
-    @agents_filtered_out_count = @agents_search_form.organisation_scope(agents_scope).count - @agents.total_count
   end
 
   def new

--- a/app/form_models/admin/agents_search_form.rb
+++ b/app/form_models/admin/agents_search_form.rb
@@ -23,5 +23,11 @@ class Admin::AgentsSearchForm
     agents_ar
   end
 
-  def resettable? = role.present? || query.present?
+  def active_filters? = role.present? || query.present?
+
+  def should_display?
+    current_organisation.agents.active.limit(10).count == 10 ||
+      (current_organisation.agent_roles.basic.any? && current_organisation.agent_roles.admin.any?) ||
+      active_filters?
+  end
 end

--- a/app/form_models/admin/agents_search_form.rb
+++ b/app/form_models/admin/agents_search_form.rb
@@ -1,0 +1,29 @@
+class Admin::AgentsSearchForm
+  include ActiveModel::Validations
+
+  attr_reader :admin_only, :query, :current_organisation
+
+  def initialize(current_organisation:, admin_only: false, query: nil)
+    @current_organisation = current_organisation
+    @admin_only = admin_only
+    @query = query
+  end
+
+  def filter_agents(agents_ar)
+    agents_ar = agents_ar.joins(:organisations).where(organisations: { id: current_organisation.id })
+    agents_ar = agents_ar.search_by_text(query) if query.present?
+    agents_ar = agents_ar.order(Arel.sql("(invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL) DESC")).ordered_by_last_name
+
+    if admin_only?
+      agents_ar = agents_ar.where(
+        id: AgentRole.where(organisation_id: current_organisation.id, access_level: AgentRole::ACCESS_LEVEL_ADMIN).select(:agent_id)
+      )
+    end
+
+    agents_ar
+  end
+
+  def admin_only? = admin_only
+
+  def resettable? = admin_only? || query.present?
+end

--- a/app/form_models/admin/agents_search_form.rb
+++ b/app/form_models/admin/agents_search_form.rb
@@ -1,11 +1,11 @@
 class Admin::AgentsSearchForm
   include ActiveModel::Validations
 
-  attr_reader :admin_only, :query, :current_organisation
+  attr_reader :role, :query, :current_organisation
 
-  def initialize(current_organisation:, admin_only: false, query: nil)
+  def initialize(current_organisation:, role: nil, query: nil)
     @current_organisation = current_organisation
-    @admin_only = admin_only
+    @role = role
     @query = query
   end
 
@@ -14,7 +14,7 @@ class Admin::AgentsSearchForm
     agents_ar = agents_ar.search_by_text(query) if query.present?
     agents_ar = agents_ar.order(Arel.sql("(invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL) DESC")).ordered_by_last_name
 
-    if admin_only?
+    if role == "admin"
       agents_ar = agents_ar.where(
         id: AgentRole.where(organisation_id: current_organisation.id, access_level: AgentRole::ACCESS_LEVEL_ADMIN).select(:agent_id)
       )
@@ -23,7 +23,5 @@ class Admin::AgentsSearchForm
     agents_ar
   end
 
-  def admin_only? = admin_only
-
-  def resettable? = admin_only? || query.present?
+  def resettable? = role.present? || query.present?
 end

--- a/app/form_models/admin/agents_search_form.rb
+++ b/app/form_models/admin/agents_search_form.rb
@@ -10,17 +10,15 @@ class Admin::AgentsSearchForm
   end
 
   def filter_agents(agents_ar)
-    agents_ar = agents_ar.joins(:organisations).where(organisations: { id: current_organisation.id })
+    agents_ar = organisation_scope(agents_ar)
     agents_ar = agents_ar.search_by_text(query) if query.present?
-    agents_ar = agents_ar.order(Arel.sql("(invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL) DESC")).ordered_by_last_name
+    agents_ar = agents_ar.merge(AgentRole.access_level_admin) if role == "admin"
+    agents_ar.order(Arel.sql("(invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL) DESC")).ordered_by_last_name
+  end
 
-    if role == "admin"
-      agents_ar = agents_ar.where(
-        id: AgentRole.where(organisation_id: current_organisation.id, access_level: AgentRole::ACCESS_LEVEL_ADMIN).select(:agent_id)
-      )
-    end
-
-    agents_ar
+  # Restreint la relation aux agents de l'organisation courante, via la table de jointure des rôles
+  def organisation_scope(agents_ar)
+    agents_ar.joins(:roles).where(agent_roles: { organisation_id: current_organisation.id })
   end
 
   def active_filters? = role.present? || query.present?

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -9,11 +9,6 @@ module AgentsHelper
     end
   end
 
-  def needs_agent_search?
-    current_organisation.agents.active.limit(10).count == 10 ||
-      (current_organisation.agent_roles.basic.any? && current_organisation.agent_roles.admin.any?)
-  end
-
   def current_agent?(agent)
     agent.id == current_agent.id
   end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -10,7 +10,8 @@ module AgentsHelper
   end
 
   def needs_agent_search?
-    current_organisation.agents.active.limit(10).count == 10
+    current_organisation.agents.active.limit(10).count == 10 ||
+      (current_organisation.agent_roles.basic.any? && current_organisation.agent_roles.admin.any?)
   end
 
   def current_agent?(agent)

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -79,6 +79,10 @@
   align-items: baseline;
 }
 
+.rdv-align-items-first-baseline {
+  align-items: first baseline;
+}
+
 .rdv-align-items-center {
   align-items: center;
 }

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -9,17 +9,17 @@
 .card
   .card-body
     - if needs_agent_search?
-      = form_with url: admin_organisation_agents_path(current_organisation), method: :get, scope: :agents_search do |f|
-        .fr-table__header.rdv-justify-content-flex-end.rdv-width-100
-          ul.fr-btns-group.fr-btns-group--right.fr-btns-group--inline-md.fr-btns-group--icon-left.fr-mb-0
-            li
-              - if agents_search_params[:query].present?
-                = link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline"
-              .fr-search-bar
-                = f.label :query, "Prénom, Nom, Email", class: "fr-label fr-sr-only"
-                = f.search_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", class: "fr-input", value: agents_search_params[:query]
-            li
+      = form_for @agents_search_form, url: admin_organisation_agents_path(current_organisation), method: :get, scope: :agents_search, builder: Dsfr::FormBuilder, as: "search" do |f|
+        fieldset.fr-fieldset.rdv-gap-1rem.rdv-justify-content-flex-end.rdv-align-items-first-baseline
+          .fr-fieldset__element--inline
+              = f.dsfr_check_box :admin_only, checked: @agents_search_form.admin_only?, label: "Uniquement les admin", class: "fr-mb-0"
+          .fr-fieldset__element--inline
+              = f.dsfr_text_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", label: ""
+          .fr-fieldset__element--inline
               = f.submit "Filtrer", class: "fr-btn"
+              - if @agents_search_form.resettable?
+                .fr-mt-1w
+                  = link_to "Réinitialiser", admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary fr-btn--sm"
     table.table
       thead
         tr

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -8,7 +8,7 @@
 
 .card
   .card-body
-    - if needs_agent_search?
+    - if @agents_search_form.should_display?
       = form_for @agents_search_form, url: admin_organisation_agents_path(current_organisation), method: :get, scope: :agents_search, builder: Dsfr::FormBuilder, as: "search" do |f|
         fieldset.fr-fieldset.rdv-gap-1rem.rdv-justify-content-flex-end.rdv-align-items-first-baseline
           .fr-fieldset__element--inline
@@ -17,7 +17,7 @@
               = f.dsfr_text_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", label: ""
           .fr-fieldset__element--inline
               = f.submit "Filtrer", class: "fr-btn"
-              - if @agents_search_form.resettable?
+              - if @agents_search_form.active_filters?
                 .fr-mt-1w
                   = link_to "Réinitialiser", admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary fr-btn--sm"
     table.table

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -9,17 +9,34 @@
 .card
   .card-body
     - if @agents_search_form.should_display?
-      = form_for @agents_search_form, url: admin_organisation_agents_path(current_organisation), method: :get, scope: :agents_search, builder: Dsfr::FormBuilder, as: "search" do |f|
-        fieldset.fr-fieldset.rdv-gap-1rem.rdv-justify-content-flex-end.rdv-align-items-first-baseline
+      = form_for @agents_search_form, url: admin_organisation_agents_path(current_organisation), method: :get, builder: Dsfr::FormBuilder, as: "search", html: { "data-controller": "form" } do |f|
+        fieldset.fr-fieldset.rdv-gap-1rem.rdv-align-items-first-baseline
+          .fr-fieldset__element--inline.fr-mr-auto
+            fieldset.fr-segmented.fr-segmented--sm.fr-segmented--no-legend
+              legend.fr-segmented__legend
+                | Rôle
+              .fr-segmented__elements
+                .fr-segmented__element
+                  = f.radio_button :role, "", checked: @agents_search_form.role != "admin", data: { action: "change->form#submit" }
+                  = f.label :role, "Tous les rôles", value: "", class: "fr-label fr-mb-0"
+                .fr-segmented__element
+                  = f.radio_button :role, "admin", data: { action: "change->form#submit" }
+                  = f.label :role, "Admins uniquement", value: "admin", class: "fr-label fr-mb-0"
           .fr-fieldset__element--inline
-            = f.dsfr_check_box :role, { label: "Uniquement les admin", class: "fr-mb-0" }, "admin", ""
+            = f.dsfr_text_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", label: ""
           .fr-fieldset__element--inline
-              = f.dsfr_text_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", label: ""
-          .fr-fieldset__element--inline
-              = f.submit "Filtrer", class: "fr-btn"
-              - if @agents_search_form.active_filters?
-                .fr-mt-1w
-                  = link_to "Réinitialiser", admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary fr-btn--sm"
+            = f.submit "Filtrer", class: "fr-btn"
+    - if @agents_search_form.active_filters? && @agents.total_count > 0
+      p.fr-text--sm.fr-mb-1w.fr-mt-4w
+        - if @agents.total_count == 1
+          | 1 agent correspond aux filtres
+        - else
+          | #{@agents.total_count} agents correspondent aux filtres
+        - if @agents_filtered_out_count== 1
+          | , 1 autre agent est caché
+        - elsif @agents_filtered_out_count > 1
+          | , #{@agents_filtered_out_count} autres agents sont cachés
+        span.fr-ml-1w= link_to "Réinitialiser les filtres", admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary fr-btn--sm"
     table.table
       thead
         tr
@@ -32,7 +49,10 @@
       tbody
         = render partial: "agent", collection: @agents
     - if @agents.empty?
-      .mb-4.p.rdv-text-align-center Aucun agent trouvé
+      .mb-4.p.rdv-text-align-center
+        | Aucun agent trouvé
+        - if @agents_search_form.active_filters?
+          span.fr-ml-1w= link_to "Réinitialiser les filtres", admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary fr-btn--sm"
     - elsif @agents.total_pages > 1
       .m-3
         .d-flex.justify-content-center

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -10,9 +10,11 @@
   .card-body
     - if @agents_search_form.should_display?
       = form_for @agents_search_form, url: admin_organisation_agents_path(current_organisation), method: :get, builder: Dsfr::FormBuilder, as: "search", html: { "data-controller": "form" } do |f|
-        fieldset.fr-fieldset.rdv-gap-1rem.rdv-align-items-first-baseline
-          .fr-fieldset__element--inline.fr-mr-auto
-            fieldset.fr-segmented.fr-segmented--sm.fr-segmented--no-legend
+        fieldset.fr-fieldset.rdv-gap-1rem.rdv-align-items-first-baseline.fr-mb-0
+          legend.fr-fieldset__legend--regular.fr-fieldset__legend.fr-mb-0.fr-pb-0
+            | Filtres
+          .fr-fieldset__element.fr-fieldset__element--inline.fr-mr-auto.fr-mb-0
+            fieldset.fr-segmented.fr-segmented--no-legend.fr-mb-0
               legend.fr-segmented__legend
                 | Rôle
               .fr-segmented__elements
@@ -22,21 +24,22 @@
                 .fr-segmented__element
                   = f.radio_button :role, "admin", data: { action: "change->form#submit" }
                   = f.label :role, "Admins uniquement", value: "admin", class: "fr-label fr-mb-0"
-          .fr-fieldset__element--inline
+          .fr-fieldset__element.fr-fieldset__element--inline.fr-mb-0
             = f.dsfr_text_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", label: ""
-          .fr-fieldset__element--inline
-            = f.submit "Filtrer", class: "fr-btn"
-    - if @agents_search_form.active_filters? && @agents.total_count > 0
-      p.fr-text--sm.fr-mb-1w.fr-mt-4w
-        - if @agents.total_count == 1
-          | 1 agent correspond aux filtres
-        - else
-          | #{@agents.total_count} agents correspondent aux filtres
-        - if @agents_filtered_out_count== 1
-          | , 1 autre agent est caché
-        - elsif @agents_filtered_out_count > 1
-          | , #{@agents_filtered_out_count} autres agents sont cachés
-        span.fr-ml-1w= link_to "Réinitialiser les filtres", admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary fr-btn--sm"
+          .fr-fieldset__element.fr-fieldset__element--inline.fr-mb-0
+            = f.submit "Rechercher", class: "fr-btn"
+
+- if @agents_search_form.active_filters? && @agents.total_count > 0
+  p.fr-mb-1w.fr-mt-4w
+    = icon("fr-icon-filter-line fr-icon--sm fr-mr-1w")
+    - if @agents.total_count == 1
+      | 1 agent correspond à vos filtres
+    - else
+      | #{@agents.total_count} agents correspondent à vos filtres
+    span.fr-ml-1w= link_to "Réinitialiser les filtres", admin_organisation_agents_path(current_organisation), class: "fr-link"
+
+.card
+  .card-body
     table.table
       thead
         tr

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -12,7 +12,7 @@
       = form_for @agents_search_form, url: admin_organisation_agents_path(current_organisation), method: :get, scope: :agents_search, builder: Dsfr::FormBuilder, as: "search" do |f|
         fieldset.fr-fieldset.rdv-gap-1rem.rdv-justify-content-flex-end.rdv-align-items-first-baseline
           .fr-fieldset__element--inline
-              = f.dsfr_check_box :admin_only, checked: @agents_search_form.admin_only?, label: "Uniquement les admin", class: "fr-mb-0"
+            = f.dsfr_check_box :role, { label: "Uniquement les admin", class: "fr-mb-0" }, "admin", ""
           .fr-fieldset__element--inline
               = f.dsfr_text_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", label: ""
           .fr-fieldset__element--inline

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -9,12 +9,17 @@
 .card
   .card-body
     - if needs_agent_search?
-      .fr-mb-2w.d-flex.justify-content-end
-        - search = params[:term].blank? && "d-none"
-        div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline #{search}"
-        = simple_form_for "", url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
-          = f.input :term, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
-          = f.submit t("helpers.search"), class: "fr-btn"
+      = form_with url: admin_organisation_agents_path(current_organisation), method: :get, scope: :agents_search do |f|
+        .fr-table__header.rdv-justify-content-flex-end.rdv-width-100
+          ul.fr-btns-group.fr-btns-group--right.fr-btns-group--inline-md.fr-btns-group--icon-left.fr-mb-0
+            li
+              - if agents_search_params[:query].present?
+                = link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline"
+              .fr-search-bar
+                = f.label :query, "Prénom, Nom, Email", class: "fr-label fr-sr-only"
+                = f.search_field :query, placeholder: "Prénom, Nom, Email", autocomplete: "off", class: "fr-input", value: agents_search_params[:query]
+            li
+              = f.submit "Filtrer", class: "fr-btn"
     table.table
       thead
         tr

--- a/spec/features/agents/agents/agent_can_search_agents_spec.rb
+++ b/spec/features/agents/agents/agent_can_search_agents_spec.rb
@@ -1,40 +1,50 @@
 RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
   let(:organisation) { create(:organisation) }
-  let(:admin) { create(:agent, first_name: "Raoul", admin_role_in_organisations: [organisation]) }
-  let!(:tony) { create(:agent, first_name: "Tony", last_name: "Patrick", basic_role_in_organisations: [organisation]) }
-  let!(:other_admin) { create(:agent, first_name: "Ada", last_name: "Minor", admin_role_in_organisations: [organisation]) }
-  let!(:other_agent1) { create(:agent, first_name: "Emilia", basic_role_in_organisations: [organisation]) }
-  let!(:other_agent2) { create(:agent, first_name: "Johana", basic_role_in_organisations: [organisation]) }
-  let!(:other_agent3) { create(:agent, first_name: "Filipo", basic_role_in_organisations: [organisation]) }
+  let(:admin) { create(:agent, first_name: "Raoul", last_name: "Jean", admin_role_in_organisations: [organisation]) }
+  let!(:tony) { create(:agent, first_name: "Tony", last_name: "Hamaz", basic_role_in_organisations: [organisation]) }
+  let!(:other_admin) { create(:agent, first_name: "Ada", last_name: "Jean", admin_role_in_organisations: [organisation]) }
+  let!(:other_agent1) { create(:agent, first_name: "Emilia", last_name: "Cori", basic_role_in_organisations: [organisation]) }
+  let!(:other_agent2) { create(:agent, first_name: "Johana", last_name: "Dupont", basic_role_in_organisations: [organisation]) }
+  let!(:other_agent3) { create(:agent, first_name: "Filipo", last_name: "Carozzo", basic_role_in_organisations: [organisation]) }
 
   specify "recherche textuelle" do
     login_as(admin, scope: :agent)
     visit admin_organisation_agents_path(organisation)
+    %w[Raoul Tony Ada Emilia Johana Filipo].each { expect(page).to have_content(_1) }
     expect(page).to have_field(placeholder: "Prénom, Nom, Email")
-    fill_in placeholder: "Prénom, Nom, Email", with: "Patrick"
+    fill_in placeholder: "Prénom, Nom, Email", with: "Jean"
     click_button "Filtrer"
-    expect(page).to have_content("PATRICK Tony")
+    expect(page).to have_content("Raoul")
+    expect(page).to have_content("Ada")
+    expect(page).not_to have_content("Tony")
     expect(page).not_to have_content("Emilia")
     expect(page).not_to have_content("Johana")
     expect(page).not_to have_content("Filipo")
+    expect(page).to have_content("2 agents correspondent aux filtres, 4 autres agents sont cachés")
 
-    click_link "Réinitialiser"
-    expect(page).to have_content("PATRICK Tony")
-    expect(page).to have_content("Emilia")
-    expect(page).to have_content("Johana")
-    expect(page).to have_content("Filipo")
+    click_link "Réinitialiser les filtres"
+    %w[Raoul Tony Ada Emilia Johana Filipo].each { expect(page).to have_content(_1) }
   end
 
   specify "filtre admin seulement" do
     login_as(admin, scope: :agent)
     visit admin_organisation_agents_path(organisation)
-    check "Uniquement les admin"
+    choose "Admins uniquement"
     click_button "Filtrer"
 
-    expect(page).to have_content("MINOR Ada")
-    expect(page).to have_no_content("PATRICK Tony")
+    expect(page).to have_content("Ada")
+    expect(page).to have_no_content("Tony")
     expect(page).not_to have_content("Emilia")
     expect(page).not_to have_content("Johana")
     expect(page).not_to have_content("Filipo")
+  end
+
+  specify "le contrôle segmenté applique le filtre immédiatement", js: true do
+    login_as(admin, scope: :agent)
+    visit admin_organisation_agents_path(organisation)
+    find("label", text: "Admins uniquement").click
+
+    expect(page).to have_content("Ada")
+    expect(page).to have_no_content("Tony")
   end
 end

--- a/spec/features/agents/agents/agent_can_search_agents_spec.rb
+++ b/spec/features/agents/agents/agent_can_search_agents_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "Un agent peut chercher des agents dans la liste" do
+  let(:organisation) { create(:organisation) }
+  let(:organisation_admin) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:tony) { create(:agent, first_name: "Tony", last_name: "Patrick", basic_role_in_organisations: [organisation]) }
+  let!(:other_agents) { create_list(:agent, 10, basic_role_in_organisations: [organisation]) }
+
+  specify do
+    login_as(organisation_admin, scope: :agent)
+    visit admin_organisation_agents_path(organisation)
+    expect(page).to have_field(placeholder: "Prénom, Nom, Email")
+    fill_in placeholder: "Prénom, Nom, Email", with: "Patrick"
+    click_button "Rechercher"
+    expect(page).to have_content("PATRICK Tony")
+    other_agents.each { |agent| expect(page).to have_no_content(agent.last_name.upcase) }
+
+    click_link "Réinitialiser"
+    expect(page).to have_content("PATRICK Tony")
+    expect(page).to have_content(other_agents.first.last_name.upcase)
+  end
+end

--- a/spec/features/agents/agents/agent_can_search_agents_spec.rb
+++ b/spec/features/agents/agents/agent_can_search_agents_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
     %w[Raoul Tony Ada Emilia Johana Filipo].each { expect(page).to have_content(_1) }
     expect(page).to have_field(placeholder: "Prénom, Nom, Email")
     fill_in placeholder: "Prénom, Nom, Email", with: "Jean"
-    click_button "Filtrer"
+    click_button "Rechercher"
     expect(page).to have_content("Raoul")
     expect(page).to have_content("Ada")
     expect(page).not_to have_content("Tony")
     expect(page).not_to have_content("Emilia")
     expect(page).not_to have_content("Johana")
     expect(page).not_to have_content("Filipo")
-    expect(page).to have_content("2 agents correspondent aux filtres, 4 autres agents sont cachés")
+    expect(page).to have_content("2 agents correspondent à vos filtres")
 
     click_link "Réinitialiser les filtres"
     %w[Raoul Tony Ada Emilia Johana Filipo].each { expect(page).to have_content(_1) }
@@ -30,7 +30,7 @@ RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
     login_as(admin, scope: :agent)
     visit admin_organisation_agents_path(organisation)
     choose "Admins uniquement"
-    click_button "Filtrer"
+    click_button "Rechercher"
 
     expect(page).to have_content("Ada")
     expect(page).to have_no_content("Tony")

--- a/spec/features/agents/agents/agent_can_search_agents_spec.rb
+++ b/spec/features/agents/agents/agent_can_search_agents_spec.rb
@@ -1,20 +1,32 @@
-RSpec.describe "Un agent peut chercher des agents dans la liste" do
+RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
   let(:organisation) { create(:organisation) }
-  let(:organisation_admin) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let(:admin) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:tony) { create(:agent, first_name: "Tony", last_name: "Patrick", basic_role_in_organisations: [organisation]) }
-  let!(:other_agents) { create_list(:agent, 10, basic_role_in_organisations: [organisation]) }
+  let!(:other_admin) { create(:agent, first_name: "Ada", last_name: "Minor", admin_role_in_organisations: [organisation]) }
+  let!(:other_agents) { create_list(:agent, 3, basic_role_in_organisations: [organisation]) }
 
-  specify do
-    login_as(organisation_admin, scope: :agent)
+  specify "recherche textuelle" do
+    login_as(admin, scope: :agent)
     visit admin_organisation_agents_path(organisation)
     expect(page).to have_field(placeholder: "Prénom, Nom, Email")
     fill_in placeholder: "Prénom, Nom, Email", with: "Patrick"
-    click_button "Rechercher"
+    click_button "Filtrer"
     expect(page).to have_content("PATRICK Tony")
     other_agents.each { |agent| expect(page).to have_no_content(agent.last_name.upcase) }
 
     click_link "Réinitialiser"
     expect(page).to have_content("PATRICK Tony")
     expect(page).to have_content(other_agents.first.last_name.upcase)
+  end
+
+  specify "filtre admin seulement" do
+    login_as(admin, scope: :agent)
+    visit admin_organisation_agents_path(organisation)
+    check "Uniquement les admin"
+    click_button "Filtrer"
+
+    expect(page).to have_content("MINOR Ada")
+    expect(page).to have_no_content("PATRICK Tony")
+    other_agents.each { |agent| expect(page).to have_no_content(agent.last_name.upcase) }
   end
 end

--- a/spec/features/agents/agents/agent_can_search_agents_spec.rb
+++ b/spec/features/agents/agents/agent_can_search_agents_spec.rb
@@ -1,9 +1,11 @@
 RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
   let(:organisation) { create(:organisation) }
-  let(:admin) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let(:admin) { create(:agent, first_name: "Raoul", admin_role_in_organisations: [organisation]) }
   let!(:tony) { create(:agent, first_name: "Tony", last_name: "Patrick", basic_role_in_organisations: [organisation]) }
   let!(:other_admin) { create(:agent, first_name: "Ada", last_name: "Minor", admin_role_in_organisations: [organisation]) }
-  let!(:other_agents) { create_list(:agent, 3, basic_role_in_organisations: [organisation]) }
+  let!(:other_agent1) { create(:agent, first_name: "Emilia", basic_role_in_organisations: [organisation]) }
+  let!(:other_agent2) { create(:agent, first_name: "Johana", basic_role_in_organisations: [organisation]) }
+  let!(:other_agent3) { create(:agent, first_name: "Filipo", basic_role_in_organisations: [organisation]) }
 
   specify "recherche textuelle" do
     login_as(admin, scope: :agent)
@@ -12,11 +14,15 @@ RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
     fill_in placeholder: "Prénom, Nom, Email", with: "Patrick"
     click_button "Filtrer"
     expect(page).to have_content("PATRICK Tony")
-    other_agents.each { |agent| expect(page).to have_no_content(agent.last_name.upcase) }
+    expect(page).not_to have_content("Emilia")
+    expect(page).not_to have_content("Johana")
+    expect(page).not_to have_content("Filipo")
 
     click_link "Réinitialiser"
     expect(page).to have_content("PATRICK Tony")
-    expect(page).to have_content(other_agents.first.last_name.upcase)
+    expect(page).to have_content("Emilia")
+    expect(page).to have_content("Johana")
+    expect(page).to have_content("Filipo")
   end
 
   specify "filtre admin seulement" do
@@ -27,6 +33,8 @@ RSpec.describe "Un agent admin peut filtrer la liste d'agents" do
 
     expect(page).to have_content("MINOR Ada")
     expect(page).to have_no_content("PATRICK Tony")
-    other_agents.each { |agent| expect(page).to have_no_content(agent.last_name.upcase) }
+    expect(page).not_to have_content("Emilia")
+    expect(page).not_to have_content("Johana")
+    expect(page).not_to have_content("Filipo")
   end
 end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6648.osc-secnum-fr1.scalingo.io/)

# Contexte

On aimerait permettre aux agents basiques de voir la liste de leurs admins pour les contacter plutôt que nous pour certains sujets. 

Je pense ouvrir la vue `admin/agents#index` aux agents basiques dans une future PR. J'aimerais cependant pouvoir rediriger les agents vers cette vue avec un filtre sur les admins. 

Dans cette première PR je n'ouvre PAS la vue aux agents basiques. 

# Solution

Je propose de rajouter le filtre « uniquement les admin » en haut de la liste des agents.

Cette nouvelle checkbox est visible pour tous les agents, peu importe leur rôle. 

## Refactos et petits changements

- je passe le formulaire au DSFR
- je change le nom du param actuel `term` en `search[query]` pour pouvoir mettre le nouveau filtre `search[admin_only]` nesté au même endroit
- je change le nom du bouton de Chercher vers Filtrer
- je déplace le bouton réinitialiser en dessous du bouton Filtrer plutôt qu’à la toute gauche des champs. 
- Cette barre de recherche en haut de la liste n'apparaissait jusqu’à maintenant que s'il y avait plus de 10 agents. Maintenant elle apparaitra aussi dès lors qu'il y a deux agents avec des rôles différents (à partir de un basique et un admin). 


# Captures

| Avant | Après |
|-|-|
|<img width="888" height="585" alt="image" src="https://github.com/user-attachments/assets/aca15863-ce39-4b72-b04f-967245960b8b" />|<img width="888" height="585" alt="image" src="https://github.com/user-attachments/assets/a2b63b53-e692-4942-a593-44fc981300d8" />|
|<img width="1265" height="726" alt="image" src="https://github.com/user-attachments/assets/bdc8fdf6-363d-46a8-84f8-d4dc1358a2f2" />|<img width="1265" height="760" alt="image" src="https://github.com/user-attachments/assets/b1954ae7-4d79-4ee1-8903-223d7cb413c5" />|
