### PR TITLE
Uniformisation de la position des boutons de soumissions config agent

### DIFF
--- a/app/views/agents/mot_de_passes/edit.html.slim
+++ b/app/views/agents/mot_de_passes/edit.html.slim
@@ -7,6 +7,6 @@
   = render "agents/mot_de_passes/new_password_hints"
 
   = f.input :current_password, hint: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
-  .d-flex.justify-content-between.rdv-align-items-baseline
-    = link_to("Retour à votre compte", edit_agent_registration_path, class: "fr-btn fr-btn--tertiary-no-outline")
+  .fr-btns-group.fr-btns-group--inline
     = f.submit "Enregistrer", class: "fr-btn"
+    = link_to("Retour à votre compte", edit_agent_registration_path, class: "fr-btn fr-btn--tertiary-no-outline")

--- a/app/views/agents/preferences/show.html.slim
+++ b/app/views/agents/preferences/show.html.slim
@@ -45,4 +45,4 @@
   .fr-alert.fr-alert--info.fr-mb-2w
     = t(".technical_email_explanation", domain_name: current_domain.name)
 
-  .text-right= f.submit t("helpers.submit.submit"), class: "fr-btn"
+  = f.submit t("helpers.submit.submit"), class: "fr-btn"

--- a/app/views/agents/registrations/_form.html.slim
+++ b/app/views/agents/registrations/_form.html.slim
@@ -14,4 +14,4 @@
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
   .form-text.fr-text-mention--grey.mb-2
     | Renseignez votre mot de passe actuel pour tout changement.
-  .text-right= f.submit "Enregistrer", class: "fr-btn"
+  = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/agents/webcal_sync/show.html.slim
+++ b/app/views/agents/webcal_sync/show.html.slim
@@ -20,6 +20,5 @@ p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la do
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 
-div.rdv-text-align-center
-  = simple_form_for(current_agent, url: agents_calendar_sync_webcal_sync_path) do |f|
-    = f.submit "Réinitialiser mon lien de synchronisation", class: "fr-btn fr-btn--secondary", data: { confirm: "Attention, si vous réinitialisez votre lien de synchronisation, vous devrez entrer le nouveau lien dans votre agenda externe" }
+= simple_form_for(current_agent, url: agents_calendar_sync_webcal_sync_path) do |f|
+  = f.submit "Réinitialiser mon lien de synchronisation", class: "fr-btn fr-btn--secondary", data: { confirm: "Attention, si vous réinitialisez votre lien de synchronisation, vous devrez entrer le nouveau lien dans votre agenda externe" }


### PR DESCRIPTION
# Contexte

Suite à un retour de @mekaidmekaid et @Teodora-Stanki je propose d’uniformiser tous les boutons de soumission de formulaire côté config agent pour qu’ils soient à gauche et non à droite (comme recommandé par le DSFR).
