### PR TITLE
Fix MVP invitation usager

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -222,7 +222,7 @@ class Rdv < ApplicationRecord
 
   def editable_by_user?
     !cancelled? && !collectif? && motif.rdvs_editable_by_user? && starts_at > 2.days.from_now &&
-      (motif.bookable_by_everyone_or_bookable_by_invited_users? || rdv_invitation)
+      (motif.bookable_by_everyone_or_bookable_by_invited_users? || rdv_invitation.present?)
   end
 
   def available_to_file_attente?


### PR DESCRIPTION
# Contexte

Le test `Rdv#editable_by_user?` échouait pour un motif non réservable en ligne (`bookable_by: :agents`) et sans invitation associée : la méthode retournait `nil` au lieu de `false`.

Cela vient de l'ajout de `rdv_invitation` dans la condition `(motif.bookable_by_everyone_or_bookable_by_invited_users? || rdv_invitation)`. Quand le motif n'est pas réservable publiquement et qu'il n'y a pas d'invitation, `rdv_invitation` vaut `nil` (association vide) et non `false`, ce qui fait remonter `nil` comme valeur du `&&` global au lieu d'un booléen strict.

# Solution

Remplacement de `rdv_invitation` par `rdv_invitation.present?` dans `editable_by_user?` afin de garantir que la méthode retourne toujours un booléen strict, quel que soit l'état de l'association.

