### PR TITLE
AMI : Vérification des autorisations avant les appels

### DIFF
--- a/app/jobs/ami/send_event_job.rb
+++ b/app/jobs/ami/send_event_job.rb
@@ -2,26 +2,22 @@ class Ami::SendEventJob < ApplicationJob
   queue_as :latency_30s
 
   def perform(payload)
-    connection.put("/api/v2/event", payload)
+    fc_hash = payload[:recipient_fc_hash]
+
+    if consent?(payload[:recipient_fc_hash])
+      connection.put("/api/v2/event", payload)
+    else
+      UserAmiProfile.find_by(fc_hash:)&.update(notify_by_ami: false)
+    end
   end
 
   private
 
-  def connection
-    Faraday.new(
-      url: ENV.fetch("AMI_URL"),
-      headers: {
-        "Authorization" => "Basic #{auth}",
-        "Content-Type" => "application/json",
-      }
-    ) do |builder|
-      builder.request :json
-      builder.response :json
-      builder.use :sentry_breadcrumbs
-    end
+  def consent?(fc_hash)
+    connection.get("/api/v1/consent/#{fc_hash}").success?
   end
 
-  def auth
-    Base64.strict_encode64("#{ENV['AMI_PARTNER_ID']}:#{ENV['AMI_PARTNER_SECRET']}")
+  def connection
+    @connection ||= AmiClient.new.connection
   end
 end

--- a/app/jobs/ami/update_consent_job.rb
+++ b/app/jobs/ami/update_consent_job.rb
@@ -1,0 +1,13 @@
+class Ami::UpdateConsentJob < ApplicationJob
+  queue_as :latency_30s
+
+  def perform(fc_hash, consent_boolean)
+    connection.post("/api/v1/consent/#{fc_hash}", { consent: consent_boolean })
+  end
+
+  private
+
+  def connection
+    @connection ||= AmiClient.new.connection
+  end
+end

--- a/app/lib/ami_client.rb
+++ b/app/lib/ami_client.rb
@@ -1,0 +1,21 @@
+class AmiClient
+  def connection
+    Faraday.new(
+      url: ENV.fetch("AMI_URL"),
+      headers: {
+        "Authorization" => "Basic #{auth}",
+        "Content-Type" => "application/json",
+      }
+    ) do |builder|
+      builder.request :json
+      builder.response :json
+      builder.use :sentry_breadcrumbs
+    end
+  end
+
+  private
+
+  def auth
+    Base64.strict_encode64("#{ENV['AMI_PARTNER_ID']}:#{ENV['AMI_PARTNER_SECRET']}")
+  end
+end

--- a/app/models/user_ami_profile.rb
+++ b/app/models/user_ami_profile.rb
@@ -7,6 +7,7 @@ class UserAmiProfile < ApplicationRecord
     return unless Ami.enabled?
 
     ami_profile = UserAmiProfile.find_by(user: user)
+    Ami::UpdateConsentJob.perform_later(ami_profile.fc_hash, boolean)
 
     ami_profile&.update(notify_by_ami: boolean)
   end

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -60,7 +60,7 @@ class Notifiers::RdvBase < BaseService
   end
 
   def notify_users_by_ami
-    User.joins(:user_ami_profile).where(user_ami_profiles: { notify_by_ami: true }).each do |user|
+    users_to_notify.joins(:user_ami_profile).where(user_ami_profiles: { notify_by_ami: true }).each do |user|
       notify_user_by_ami(user)
     end
   end

--- a/spec/services/ami_spec.rb
+++ b/spec/services/ami_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Ami do
 
   before do
     UserAmiProfile.create!(user: user, fc_hash: "test_ami_fc_hash")
+    WebMock.stub_request(:get, "https://ami.test/api/v1/consent/test_ami_fc_hash").to_return(
+      status: 200, body: '{"consent_datetime": "2026-09-02T13:05:56.256266Z"}'
+    )
     WebMock.stub_request(:put, "https://ami.test/api/v2/event")
   end
 


### PR DESCRIPTION
AMI a livré en staging une nouvelle api de gestion des permissions, on peut maintenant les mettre à jour de leur côté.

On garde un "cache" local avec notre colonne `user_ami_profiles.notify_with_ami` qui permet d'éviter de faire un appel api à ami à chaque fois qu'on affiche une page de confirmation de rdv.
On fait une requête à l'endpoint de gestion des permissions à chaque écrire à ami, ce qui permet d'invalider le cache si nécessaire.

La doc de l'api : https://ami-back-staging.osc-fr1.scalingo.io/schema/rapidoc