### PR TITLE
Correctif pour la recherche de créneaux avec le feature flag des invitations mais sans usager

### DIFF
--- a/app/views/admin/creneaux_search/selection_creneaux.html.slim
+++ b/app/views/admin/creneaux_search/selection_creneaux.html.slim
@@ -22,7 +22,7 @@
           form: @form, \
           next_availability: @search_result.next_availability
 
-        - if current_agent.feature_enabled?("rdv_invitations") && params[:user_ids].count == 1
+        - if current_agent.feature_enabled?("rdv_invitations") && params[:user_ids]&.count == 1
           p.fr-mt-2w Vous pouvez aussi #{link_to("inviter l'usager à choisir son créneau", new_admin_organisation_rdv_invitation_path(current_organisation, motif_id: params[:motif_id], lieu_id: params[:lieu_ids].first, user_id: params[:user_ids].first))}.
 
   - if  @form.motif.collectif?


### PR DESCRIPTION
Un petit correctif pour le cas d'une recherche de créneaux sans usager pour un agent pour lequel on a activé le feature flag des invitations.