### PR TITLE
Création d’une nouvelle clef session[:agent]

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -38,7 +38,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
 
     form = Admin::OnlineBookingMotifsForm.new(current_organisation)
 
-    form.submit(params.dig(:admin_online_booking_motifs_form, :motif_ids), flash, session)
+    form.submit(params.dig(:admin_online_booking_motifs_form, :motif_ids), flash, agent_session)
 
     redirect_to admin_organisation_online_booking_path(current_organisation)
   end

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -1,5 +1,6 @@
 class Admin::Planning::PlageOuverturesController < AgentAuthController
   include Admin::Planning::PlanningConcern
+
   respond_to :html, :json
 
   before_action :set_plage_ouverture, only: %i[show edit update destroy]
@@ -106,11 +107,11 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   private
 
   def update_online_booking_banner_display
-    if session["OnlineBookingMotifsForm:completed"]
+    if agent_session["OnlineBookingMotifsForm:completed"]
       banner = OnlineBookingOnboardingBanner.new(current_organisation)
       # S'il n'y a plus besoin de la bannière, on arrête de l'afficher
       unless banner.availabilities_needed?
-        session.delete("OnlineBookingMotifsForm:completed")
+        agent_session.delete("OnlineBookingMotifsForm:completed")
         flash[:onboarding] = "online_booking_ready"
       end
     end

--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -81,9 +81,14 @@ class Admin::RdvWizardStepsController < AgentAuthController
     return unless current_step == "step4"
     return unless @rdv.motif&.visio?
     return if ENV["VISIO_NUMERIQUE_DISABLED"]
-    return if agent_session[:pro_connect_access_token].blank?
 
-    result = VisioNumerique::CreateRoom.new(access_token: agent_session[:pro_connect_access_token]).call
+    # TODO: retirer le fallback `session[:pro_connect_access_token]` une fois la fenêtre de MEP passée
+    # (durée de vie max d'une session agent : 8h, cf `config.session_store` dans application.rb).
+    # Avant cette migration, le jeton était stocké à cette clé plate au lieu de `agent_session`.
+    access_token = agent_session[:pro_connect_access_token] || session[:pro_connect_access_token]
+    return if access_token.blank?
+
+    result = VisioNumerique::CreateRoom.new(access_token:).call
     @rdv.visio_url_custom = result["url"]
   rescue VisioNumerique::CreateRoom::ApiError => e
     Rails.logger.error("Visio Numerique API error: #{e.message}")

--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -70,7 +70,7 @@ class Admin::RdvWizardStepsController < AgentAuthController
   def set_services_and_motifs
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent)
     @services = Service.where(id: @motifs.pluck(:service_id).uniq)
-    @rdv_wizard.service_id = @services.first.id if @services.count == 1
+    @rdv_wizard.service_id = @services.first.id if @services.one?
   end
 
   # Cette méthode est dans le controller plutôt que dans le visio_concern car la création du salon
@@ -81,9 +81,9 @@ class Admin::RdvWizardStepsController < AgentAuthController
     return unless current_step == "step4"
     return unless @rdv.motif&.visio?
     return if ENV["VISIO_NUMERIQUE_DISABLED"]
-    return if session[:pro_connect_access_token].blank?
+    return if agent_session[:pro_connect_access_token].blank?
 
-    result = VisioNumerique::CreateRoom.new(access_token: session[:pro_connect_access_token]).call
+    result = VisioNumerique::CreateRoom.new(access_token: agent_session[:pro_connect_access_token]).call
     @rdv.visio_url_custom = result["url"]
   rescue VisioNumerique::CreateRoom::ApiError => e
     Rails.logger.error("Visio Numerique API error: #{e.message}")

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -1,5 +1,6 @@
 class AgentAuthController < ApplicationController
   include Admin::AuthenticatedControllerConcern
+  include Agents::SessionConcern
 
   layout "application_agent"
 
@@ -33,7 +34,7 @@ class AgentAuthController < ApplicationController
     return unless path_org_id
 
     @current_organisation = Organisation.find(path_org_id).tap do |found_org|
-      session[:latest_used_organisation_id] = found_org.id if found_org
+      agent_session[:latest_used_organisation_id] = found_org.id if found_org
     end
   end
 

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -1,4 +1,6 @@
 class Agents::SessionsByCodeController < ApplicationController
+  include Agents::SessionConcern
+
   SESSION_AGENT_ID_KEY = :pending_agent_login_id
   SESSION_PRO_CONNECT_ID_TOKEN_KEY = :pending_pro_connect_id_token
 
@@ -23,7 +25,7 @@ class Agents::SessionsByCodeController < ApplicationController
       validator.valid_login_code.update!(used_at: Time.zone.now)
       session.delete(SESSION_AGENT_ID_KEY)
       if session[SESSION_PRO_CONNECT_ID_TOKEN_KEY]
-        session[:pro_connect_id_token] = session.delete(SESSION_PRO_CONNECT_ID_TOKEN_KEY)
+        agent_session[:pro_connect_id_token] = session.delete(SESSION_PRO_CONNECT_ID_TOKEN_KEY)
       end
       sign_in(agent, scope: :agent)
       redirect_to after_sign_in_path_for(agent)

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -1,6 +1,7 @@
 class Agents::SessionsController < Devise::SessionsController
   include Admin::WeakPasswordControllerConcern
   include DomainRedirectionAfterLogin
+  include Agents::DeviseOrSsoLogout
 
   # Lorsqu'un agent est connecté à une application Oauth via notre application,
   # Il est possible qu'il cherche à se déconnecter alors que sa session a déjà expiré.
@@ -30,7 +31,7 @@ class Agents::SessionsController < Devise::SessionsController
     self.resource = warden.authenticate!(auth_options)
 
     if resource.pro_connect_openid_sub.present?
-      sign_out(resource)
+      sign_out_agent!(resource)
       redirect_to new_agent_session_path(pro_connect_required: resource.email)
       return
     end
@@ -38,7 +39,7 @@ class Agents::SessionsController < Devise::SessionsController
     return if reset_current_agent_password_if_weak!(params[:agent][:password])
 
     if resource.sensitive_account?
-      sign_out(resource)
+      sign_out_agent!(resource)
       session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = resource.id
       Agents::LoginCodeSender.perform(email: resource.email, domain_id: current_domain.id)
       redirect_to new_agents_sessions_by_code_path
@@ -46,7 +47,7 @@ class Agents::SessionsController < Devise::SessionsController
     end
 
     if should_redirect_to_domain_anct?(current_domain, resource)
-      sign_out(resource)
+      sign_out_agent!(resource)
       redirect_to redirect_target_url_in_domain(Domain::RDV_SERVICE_PUBLIC), allow_other_host: true
       return
     end
@@ -70,13 +71,10 @@ class Agents::SessionsController < Devise::SessionsController
       @oauth_client_app_post_logout_redirect_url = oauth_app.post_logout_redirect_uri
     end
 
-    pro_connect_id_token = session.delete(:pro_connect_id_token)
-
-    sign_out(:agent)
+    pro_connect_id_token = sign_out_agent!(:agent)
 
     # Si on redirige vers l'app cliente, on n'aura pas de render pendant lequel le flash s'affichera, donc on ne l'ajoute pas.
     if @oauth_client_app_post_logout_redirect_url
-      # On est obligés de modifier la session ici puisque l'appel à `sign_out(:agent)` a effacé la session
       session[:post_logout_redirect_url] = @oauth_client_app_post_logout_redirect_url
     else
       set_flash_message!(:notice, :signed_out)

--- a/app/controllers/concerns/agents/devise_or_sso_logout.rb
+++ b/app/controllers/concerns/agents/devise_or_sso_logout.rb
@@ -8,7 +8,10 @@ module Agents::DeviseOrSsoLogout
   # pourraient profiter à un autre agent se connectant ensuite depuis le même navigateur (poste
   # partagé).
   def sign_out_agent!(agent_or_scope)
-    pro_connect_id_token = agent_session[:pro_connect_id_token]
+    # TODO: retirer le fallback `session[:pro_connect_id_token]` une fois la fenêtre de MEP passée
+    # (durée de vie max d'une session agent : 8h, cf `config.session_store` dans application.rb).
+    # Avant cette migration, le jeton était stocké à cette clé plate au lieu de `agent_session`.
+    pro_connect_id_token = agent_session[:pro_connect_id_token] || session[:pro_connect_id_token]
     clear_agent_session!
     sign_out(agent_or_scope)
     pro_connect_id_token

--- a/app/controllers/concerns/agents/devise_or_sso_logout.rb
+++ b/app/controllers/concerns/agents/devise_or_sso_logout.rb
@@ -1,0 +1,14 @@
+module Agents::DeviseOrSsoLogout
+  extend ActiveSupport::Concern
+
+  # `sign_out` appelé avec un scope explicite (`sign_out(:agent)`, `sign_out(resource)`) ne vide pas
+  # la session Rails : seules les clés Warden internes sont retirées. Sans ce nettoyage, des jetons
+  # ProConnect sensibles survivraient à la déconnexion et pourraient profiter à un autre agent se
+  # connectant ensuite depuis le même navigateur (poste partagé).
+  def sign_out_agent!(agent_or_scope)
+    session.delete(:pro_connect_access_token)
+    pro_connect_id_token = session.delete(:pro_connect_id_token)
+    sign_out(agent_or_scope)
+    pro_connect_id_token
+  end
+end

--- a/app/controllers/concerns/agents/devise_or_sso_logout.rb
+++ b/app/controllers/concerns/agents/devise_or_sso_logout.rb
@@ -1,13 +1,15 @@
 module Agents::DeviseOrSsoLogout
   extend ActiveSupport::Concern
+  include Agents::SessionConcern
 
   # `sign_out` appelé avec un scope explicite (`sign_out(:agent)`, `sign_out(resource)`) ne vide pas
-  # la session Rails : seules les clés Warden internes sont retirées. Sans ce nettoyage, des jetons
-  # ProConnect sensibles survivraient à la déconnexion et pourraient profiter à un autre agent se
-  # connectant ensuite depuis le même navigateur (poste partagé).
+  # la session Rails : seules les clés Warden internes sont retirées. Sans ce nettoyage, les données
+  # stockées dans `agent_session` (jetons ProConnect, etc.) survivraient à la déconnexion et
+  # pourraient profiter à un autre agent se connectant ensuite depuis le même navigateur (poste
+  # partagé).
   def sign_out_agent!(agent_or_scope)
-    session.delete(:pro_connect_access_token)
-    pro_connect_id_token = session.delete(:pro_connect_id_token)
+    pro_connect_id_token = agent_session[:pro_connect_id_token]
+    clear_agent_session!
     sign_out(agent_or_scope)
     pro_connect_id_token
   end

--- a/app/controllers/concerns/agents/session_concern.rb
+++ b/app/controllers/concerns/agents/session_concern.rb
@@ -1,0 +1,21 @@
+module Agents::SessionConcern
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :agent_session
+  end
+
+  # Toute donnée de session propre à un agent connecté doit passer par ce hash plutôt que par des
+  # clés éparpillées à la racine de la session : ça permet de tout nettoyer d'un coup à la
+  # déconnexion (`clear_agent_session!`) sans risquer d'oublier une clé au fil des évolutions, et
+  # sans toucher aux autres scopes Devise potentiellement actifs dans la même session (ex : un
+  # super admin connecté en tant qu'agent, cf. `session[:super_admin_signed_in_as_agent]`, qui doit
+  # survivre à la déconnexion de l'agent usurpé).
+  def agent_session
+    session[:agent] = (session[:agent] || {}).with_indifferent_access
+  end
+
+  def clear_agent_session!
+    session.delete(:agent)
+  end
+end

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -2,6 +2,7 @@
 
 class ProConnectController < ApplicationController
   include DomainRedirectionAfterLogin
+  include Agents::DeviseOrSsoLogout
 
   # IDP ProConnect nécessitant une double authentification pour les agents qui ont des comptes sensibles.
   # Configurable via la variable d'environnement IDP_PRO_CONNECT_FORCE_2FA_ENABLED (liste séparée par des virgules).
@@ -229,13 +230,13 @@ class ProConnectController < ApplicationController
     end
 
     if should_redirect_to_domain_etat?(current_domain, agent)
-      sign_out(agent)
+      sign_out_agent!(agent)
       redirect_to redirect_target_url_in_domain(Domain::RDV_SERVICE_PUBLIC_ETAT), allow_other_host: true
       return
     end
 
     if should_redirect_to_domain_anct?(current_domain, agent)
-      sign_out(agent)
+      sign_out_agent!(agent)
       redirect_to redirect_target_url_in_domain(Domain::RDV_SERVICE_PUBLIC), allow_other_host: true
       return
     end

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -222,8 +222,8 @@ class ProConnectController < ApplicationController
     agent.save!
 
     bypass_sign_in agent, scope: :agent
-    session[:pro_connect_id_token] = callback_client.id_token_for_logout
-    session[:pro_connect_access_token] = callback_client.access_token
+    agent_session[:pro_connect_id_token] = callback_client.id_token_for_logout
+    agent_session[:pro_connect_access_token] = callback_client.access_token
 
     if pro_connect_session[:silent_login]
       flash[:login] = "Vous avez été connecté automatiquement par ProConnect avec l'adresse email #{agent.email}."

--- a/app/form_models/admin/online_booking_motifs_form.rb
+++ b/app/form_models/admin/online_booking_motifs_form.rb
@@ -8,7 +8,7 @@ class Admin::OnlineBookingMotifsForm
     @motif_ids = motifs.bookable_by_everyone.pluck(:id)
   end
 
-  def submit(new_motif_ids, flash, session)
+  def submit(new_motif_ids, flash, agent_session)
     new_motif_ids ||= []
 
     motifs_open_before_update = motifs.bookable_by_everyone.any?
@@ -23,7 +23,7 @@ class Admin::OnlineBookingMotifsForm
 
     motifs_open_after_update = motifs.bookable_by_everyone.any?
 
-    prepare_flash_and_session(flash, session, motifs_open_before_update, motifs_open_after_update)
+    prepare_flash_and_session(flash, agent_session, motifs_open_before_update, motifs_open_after_update)
   end
 
   private
@@ -32,7 +32,7 @@ class Admin::OnlineBookingMotifsForm
     @motifs ||= @organisation.motifs.active
   end
 
-  def prepare_flash_and_session(flash, session, motifs_open_before_update, motifs_open_after_update)
+  def prepare_flash_and_session(flash, agent_session, motifs_open_before_update, motifs_open_after_update)
     if motifs_open_before_update
       if motifs_open_after_update
         flash[:success] = "La liste des motifs ouverts à la réservation en ligne a été mise à jour."
@@ -40,21 +40,21 @@ class Admin::OnlineBookingMotifsForm
         flash[:notice] = "La réservation en ligne a été fermée"
       end
     elsif motifs_open_after_update
-      prepare_flash_and_session_for_activation(flash, session)
+      prepare_flash_and_session_for_activation(flash, agent_session)
     else
       flash[:error] = "Vous devez choisir au moins un motif pour ouvrir la réservation en ligne"
     end
   end
 
-  def prepare_flash_and_session_for_activation(flash, session)
+  def prepare_flash_and_session_for_activation(flash, agent_session)
     banner = OnlineBookingOnboardingBanner.new(@organisation)
 
     if banner.availabilities_needed?
       # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre
-      session["OnlineBookingMotifsForm:completed"] = true
+      agent_session["OnlineBookingMotifsForm:completed"] = true
     else
       motif_names = motifs.bookable_by_everyone.pluck(:name)
-      flash[:success] = if motif_names.count == 1
+      flash[:success] = if motif_names.one?
                           "Le motif #{motif_names.first} est ouvert pour la réservation en ligne."
                         else
                           "Les motifs #{motif_names.to_sentence} sont ouverts pour la réservation en ligne."

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -4,7 +4,7 @@
   | Réservation en ligne
 
 - content_for :onboarding_banner do
-  - if @banner.availabilities_needed? && session["OnlineBookingMotifsForm:completed"]
+  - if @banner.availabilities_needed? && agent_session["OnlineBookingMotifsForm:completed"]
     .fr-callout.fr-pb-2w
       h2.fr-h6 🎉 Vous y êtes presque !
 

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -25,7 +25,7 @@ html lang="fr"
           .p-2
             = link_logo
           - if current_agent
-            - latest_org_id = current_agent.organisation_ids.find { _1 == session[:latest_used_organisation_id].to_i }
+            - latest_org_id = current_agent.organisation_ids.find { _1 == agent_session[:latest_used_organisation_id].to_i }
             - accueil = latest_org_id ? admin_organisation_planning_agenda_path(organisation_id: latest_org_id) : root_path
             = link_to(accueil, class: "pt-1 pb-4") do
               i.fr-icon-arrow-left-line

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Admin::RdvWizardStepsController, type: :controller do
 
     it "creates the rdv and flashes success" do
       expect { create_request }.to change(Rdv, :count).by(1)
-      expect(flash[:success]).to match(/Le rendez-vous a été créé/)
+      expect(flash[:success]).to include("Le rendez-vous a été créé")
     end
 
     context "when the rdv is in the past" do
@@ -104,7 +104,7 @@ RSpec.describe Admin::RdvWizardStepsController, type: :controller do
     context "with a visio motif and a ProConnect access_token in session" do
       let(:motif) { create(:motif, location_type: :visio) }
 
-      before { session[:pro_connect_access_token] = "un-token" }
+      before { session[:agent] = { pro_connect_access_token: "un-token" } }
 
       it "creates a Visio Numérique room and assigns its url" do
         stub_request(:post, "#{VisioNumerique::CreateRoom::DEFAULT_API_URL}/rooms/")

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -127,6 +127,21 @@ RSpec.describe Admin::RdvWizardStepsController, type: :controller do
         end
       end
     end
+
+    context "avec un motif visio et seulement l'ancien jeton pro_connect_access_token à plat en session" do
+      let(:motif) { create(:motif, location_type: :visio) }
+
+      before { session[:pro_connect_access_token] = "un-ancien-token" }
+
+      it "crée une salle Visio Numérique en utilisant le jeton de fallback" do
+        stub_request(:post, "#{VisioNumerique::CreateRoom::DEFAULT_API_URL}/rooms/")
+          .to_return(status: 200, body: { url: "https://visio.numerique.gouv.fr/room-xyz" }.to_json, headers: { "Content-Type" => "application/json" })
+
+        create_request
+
+        expect(Rdv.last.visio_url_custom).to eq("https://visio.numerique.gouv.fr/room-xyz")
+      end
+    end
   end
 
   context "POST step2 avec motif téléphonique et l’usager a un numéro de téléphone" do

--- a/spec/controllers/agents/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/agents/sessions_by_code_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Agents::SessionsByCodeController, type: :controller do
 
           it "transfère le token vers pro_connect_id_token et supprime le pending" do
             post :create, params: { login_code: { code: login_code.code } }
-            expect(session[:pro_connect_id_token]).to eq("fake_pro_connect_token")
+            expect(session[:agent][:pro_connect_id_token]).to eq("fake_pro_connect_token")
             expect(session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY]).to be_nil
           end
         end

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -16,12 +16,10 @@ RSpec.describe Agents::SessionsController do
         expect(session["warden.agent.key"]).to be_nil
       end
 
-      it "efface les jetons ProConnect de la session" do
-        session[:pro_connect_access_token] = "fake_access_token"
-        session[:pro_connect_id_token] = "fake_id_token"
+      it "efface la session propre à l'agent (jetons ProConnect inclus)" do
+        session[:agent] = { pro_connect_access_token: "fake_access_token", pro_connect_id_token: "fake_id_token" }
         post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
-        expect(session[:pro_connect_access_token]).to be_nil
-        expect(session[:pro_connect_id_token]).to be_nil
+        expect(session[:agent]).to be_nil
       end
     end
 
@@ -60,12 +58,10 @@ RSpec.describe Agents::SessionsController do
         expect(LoginCode.last.email).to eq(agent.email)
       end
 
-      it "efface les jetons ProConnect de la session" do
-        session[:pro_connect_access_token] = "fake_access_token"
-        session[:pro_connect_id_token] = "fake_id_token"
+      it "efface la session propre à l'agent (jetons ProConnect inclus)" do
+        session[:agent] = { pro_connect_access_token: "fake_access_token", pro_connect_id_token: "fake_id_token" }
         post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
-        expect(session[:pro_connect_access_token]).to be_nil
-        expect(session[:pro_connect_id_token]).to be_nil
+        expect(session[:agent]).to be_nil
       end
     end
   end
@@ -73,10 +69,10 @@ RSpec.describe Agents::SessionsController do
   describe "#destroy" do
     before { sign_in agent }
 
-    it "efface le jeton d'accès ProConnect de la session" do
-      session[:pro_connect_access_token] = "fake_access_token"
+    it "efface la session propre à l'agent (jetons ProConnect inclus)" do
+      session[:agent] = { pro_connect_access_token: "fake_access_token" }
       get :destroy
-      expect(session[:pro_connect_access_token]).to be_nil
+      expect(session[:agent]).to be_nil
     end
 
     context "when the agent was logged in with ProConnect" do
@@ -85,12 +81,12 @@ RSpec.describe Agents::SessionsController do
       before do
         ProConnectStubs.stub_and_run_discover_request
         # C'est compliqué de manipuler la session dans une feature spec, c'est pour ça qu'on utilise une spec de controller ici
-        session[:pro_connect_id_token] = "fake_pro_connect_id_token"
+        session[:agent] = { pro_connect_id_token: "fake_pro_connect_id_token" }
       end
 
       it "signs out the agent and redirects them to the ProConnect logout url with the right params" do
         get :destroy
-        expect(session[:pro_connect_id_token]).to be_nil
+        expect(session[:agent]).to be_nil
 
         redirect_url = response.headers["Location"]
 

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Agents::SessionsController do
         expect(response).to redirect_to(new_agent_session_path(pro_connect_required: agent.email))
         expect(session["warden.agent.key"]).to be_nil
       end
+
+      it "efface les jetons ProConnect de la session" do
+        session[:pro_connect_access_token] = "fake_access_token"
+        session[:pro_connect_id_token] = "fake_id_token"
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+        expect(session[:pro_connect_access_token]).to be_nil
+        expect(session[:pro_connect_id_token]).to be_nil
+      end
     end
 
     context "when the agent does not have a pro_connect_openid_sub" do
@@ -51,11 +59,25 @@ RSpec.describe Agents::SessionsController do
           .and have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
         expect(LoginCode.last.email).to eq(agent.email)
       end
+
+      it "efface les jetons ProConnect de la session" do
+        session[:pro_connect_access_token] = "fake_access_token"
+        session[:pro_connect_id_token] = "fake_id_token"
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+        expect(session[:pro_connect_access_token]).to be_nil
+        expect(session[:pro_connect_id_token]).to be_nil
+      end
     end
   end
 
   describe "#destroy" do
     before { sign_in agent }
+
+    it "efface le jeton d'accès ProConnect de la session" do
+      session[:pro_connect_access_token] = "fake_access_token"
+      get :destroy
+      expect(session[:pro_connect_access_token]).to be_nil
+    end
 
     context "when the agent was logged in with ProConnect" do
       stub_env_with(PRO_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2")

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -101,5 +101,24 @@ RSpec.describe Agents::SessionsController do
         )
       end
     end
+
+    context "quand l'agent s'est connecté avec ProConnect avant la migration vers agent_session" do
+      stub_env_with(PRO_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2")
+
+      before do
+        ProConnectStubs.stub_and_run_discover_request
+        # simule une session créée avant la migration vers agent_session, avec la clé plate uniquement
+        session[:pro_connect_id_token] = "fake_pro_connect_id_token"
+      end
+
+      it "déconnecte l'agent et le redirige vers l'URL de déconnexion ProConnect en utilisant le jeton de fallback" do
+        get :destroy
+
+        redirect_url = response.headers["Location"]
+        redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
+
+        expect(redirect_url_query_params["id_token_hint"]).to eq("fake_pro_connect_id_token")
+      end
+    end
   end
 end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ProConnectController do
         }
         expect(agent).to have_attributes(expected_attrs)
         expect(current_agent_id).to eq(agent.id)
-        expect(session["pro_connect_id_token"]).to be_present
+        expect(session[:agent][:pro_connect_id_token]).to be_present
         expect(response).to redirect_to("/agents/edit")
       end
 
@@ -162,7 +162,7 @@ RSpec.describe ProConnectController do
           }
           expect(agent).to have_attributes(expected_attrs)
           expect(current_agent_id).to eq(agent.id)
-          expect(session["pro_connect_id_token"]).to be_present
+          expect(session[:agent][:pro_connect_id_token]).to be_present
           expect(response).to redirect_to("/agents/edit") # stored location via after_sign_in_path_for
         end
       end
@@ -362,13 +362,12 @@ RSpec.describe ProConnectController do
       context "quand l'agent est redirigé vers un autre domaine juste après sa connexion" do
         before { allow(controller).to receive(:should_redirect_to_domain_etat?).and_return(true) }
 
-        it "efface les jetons ProConnect de la session avant la redirection" do
+        it "efface la session propre à l'agent (jetons ProConnect inclus) avant la redirection" do
           create(:agent, email: user_info["email"])
           get :callback, params: { state:, code: }
 
           expect(response).to redirect_to(start_with("http://"))
-          expect(session[:pro_connect_access_token]).to be_nil
-          expect(session[:pro_connect_id_token]).to be_nil
+          expect(session[:agent]).to be_nil
         end
       end
     end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -358,6 +358,19 @@ RSpec.describe ProConnectController do
           end
         end
       end
+
+      context "quand l'agent est redirigé vers un autre domaine juste après sa connexion" do
+        before { allow(controller).to receive(:should_redirect_to_domain_etat?).and_return(true) }
+
+        it "efface les jetons ProConnect de la session avant la redirection" do
+          create(:agent, email: user_info["email"])
+          get :callback, params: { state:, code: }
+
+          expect(response).to redirect_to(start_with("http://"))
+          expect(session[:pro_connect_access_token]).to be_nil
+          expect(session[:pro_connect_id_token]).to be_nil
+        end
+      end
     end
 
     context "when logging in a user" do


### PR DESCRIPTION
# Contexte

`sign_out` appelé avec un scope explicite (`sign_out(:agent)`, `sign_out(resource)`) ne vide pas la session Rails : seules les clés Warden internes sont retirées. Les clés applicatives (jetons ProConnect, dernière organisation utilisée, etc.), elles, étaient stockées à la racine de la session et survivaient donc à la déconnexion d'un agent. Sur un poste partagé, un agent pouvait ainsi hériter de données de session laissées par l'agent précédent.

# Solution

Toutes les données de session propres à un agent connecté sont regroupées sous une seule clé namespacée `session[:agent]`, accessible via le helper `agent_session` (`Agents::SessionConcern`). Ça permet de tout nettoyer d'un coup à la déconnexion, sans toucher aux autres scopes Devise potentiellement actifs dans la même session (ex : un super admin connecté en tant qu'agent via usurpation, qui doit survivre à la déconnexion de l'agent usurpé).

- Nouveau concern `Agents::SessionConcern` : `agent_session` (accesseur à `session[:agent]`, exposé aux vues) et `clear_agent_session!`.
- `Agents::DeviseOrSsoLogout#sign_out_agent!` fait un seul `clear_agent_session!` au lieu de supprimer les clés une par une.
- Clés migrées vers `agent_session` : `pro_connect_id_token`, `pro_connect_access_token`, `latest_used_organisation_id`, ainsi que le flag de complétion du formulaire de motifs pour la réservation en ligne.
- Refacto pur, sans changement de comportement fonctionnel pour un agent qui se connecte après le déploiement.
- Ajout d'un fallback temporaire sur les anciennes clés de session à plat (`session[:pro_connect_id_token]`, `session[:pro_connect_access_token]`) pour ne pas casser la déconnexion ProConnect ni la création de salle Visio Numérique pour les agents déjà connectés au moment de la mise en production. Ce fallback pourra être retiré une fois la durée de vie maximale d'une session agent (8h) écoulée après le déploiement.
