### PR TITLE
Ajout d'index utile sur `agent_roles`

### DIFF
--- a/db/migrate/20260902074544_add_index_on_agent_roles_agent_id_organisation_id.rb
+++ b/db/migrate/20260902074544_add_index_on_agent_roles_agent_id_organisation_id.rb
@@ -1,0 +1,14 @@
+class AddIndexOnAgentRolesAgentIdOrganisationId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # ceci est un covering index, il permet donc de récupérer la liste des orgas d'un agent via un "Index-Only Scan"
+    add_index :agent_roles, %i[agent_id organisation_id], include: %i[access_level agent_accueil], unique: true, algorithm: :concurrently
+    add_index :agent_roles, :organisation_id, algorithm: :concurrently
+
+    # devient inutile avec l'ajout de l'index ci-dessus
+    remove_index :agent_roles, :agent_id, algorithm: :concurrently
+    remove_index :agent_roles, :access_level, algorithm: :concurrently
+    remove_index :agent_roles, %i[organisation_id agent_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_26_074818) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_02_074544) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -64,9 +64,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_26_074818) do
     t.bigint "organisation_id", null: false
     t.enum "access_level", default: "basic", null: false, enum_type: "access_level"
     t.boolean "agent_accueil", default: false, null: false
-    t.index ["access_level"], name: "index_agent_roles_on_access_level"
-    t.index ["agent_id"], name: "index_agent_roles_on_agent_id"
-    t.index ["organisation_id", "agent_id"], name: "index_agent_roles_on_organisation_id_and_agent_id", unique: true
+    t.index ["agent_id", "organisation_id"], name: "index_agent_roles_on_agent_id_and_organisation_id", unique: true, include: ["access_level", "agent_accueil"]
+    t.index ["organisation_id"], name: "index_agent_roles_on_organisation_id"
   end
 
   create_table "agent_services", force: :cascade do |t|


### PR DESCRIPTION
# Contexte

En regardant la définition de la table `agent_roles`, j'ai constaté qu'il y avait un index sur `access_level`, totalement inutile.

Je me suis alors demandé quels index seraient idéaux sur **cette table qui est requêtée à chaque page agent affichée** (voir `Agent::PreloadRoles`).

# Solution

La grande majorité du temps (et à chaque affichage de page agent), nous avons besoin de récupérer les rôles d'un agent. Je pense donc qu'un covering index est pertinent pour cet usage. 

Si vous n'êtes pas familier avec les covering index et l'index-only scan, sachez que cette page est une lecture enthousiasmante :star_struck:  : https://www.postgresql.org/docs/current/indexes-index-only-scans.html

J'ai aussi gardé un index juste sur `organisation_id` qui pourra nous servir quand on veut faire des jointures pour restreindre aux agents d'une orga donnée.

Je ne crois pas qu'un autre index soit nécessaire.

### L'unicité

Comme la doc l'indique, l'unicité ne porte que sur les colonnes qui construisent l'index, pas celle qui sont inclues :

> the uniqueness condition applies to just column x, not to the combination of x and y.

donc c'est exactement ce qu'on veut.