### PR TITLE
Ajout des agents d’accueil dans les règles pour les sensitives account

### DIFF
--- a/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
+++ b/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
@@ -1,14 +1,14 @@
 class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
-  SENSITIVE_TERRITORY_RDV_THRESHOLD = 5_000
+  SENSITIVE_RDV_THRESHOLD = 5_000
 
   def perform
     return if disabled?
 
-    sensitive_ids = (sensitive_territory_admin_ids + rdv_insertion_admin_agent_ids).uniq
+    sensitive_ids = (sensitive_agent_role_ids + sensitive_territory_admin_ids + rdv_insertion_admin_agent_ids).uniq
 
     # rubocop:disable Rails/SkipsModelValidations
     Agent.where(id: sensitive_ids).in_batches.update_all(sensitive_account: true)
-    Agent.where(id: territory_admin_ids).where.not(id: sensitive_ids).in_batches.update_all(sensitive_account: false)
+    Agent.where(id: evaluated_agent_ids).where.not(id: sensitive_ids).in_batches.update_all(sensitive_account: false)
     # rubocop:enable Rails/SkipsModelValidations
   end
 
@@ -18,18 +18,37 @@ class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
     ENV["DISABLE_REFRESH_AGENTS_SENSITIVE_ACCOUNT_JOB"] == "true"
   end
 
-  def territory_admin_ids
-    AgentTerritorialRole.distinct.pluck(:agent_id)
+  # Tous les agents susceptibles d'être concernés par l'un des critères ci-dessous,
+  # pour pouvoir repasser sensitive_account à false s'ils ne les remplissent plus.
+  def evaluated_agent_ids
+    (admin_or_agent_accueil_agent_ids + AgentTerritorialRole.distinct.pluck(:agent_id)).uniq
+  end
+
+  def admin_or_agent_accueil_agent_ids
+    AgentRole.where("access_level = 'admin' OR agent_accueil = true").distinct.pluck(:agent_id)
+  end
+
+  # Un agent a accès à l'ensemble des RDVs d'une organisation (et non uniquement aux siens)
+  # dès lors qu'il y a un rôle admin ou agent_accueil (cf. Agent::RdvPolicy::Scope). Le volume
+  # est cumulé sur toutes les organisations où l'agent a un tel rôle.
+  def sensitive_agent_role_ids
+    AgentRole.where("access_level = 'admin' OR agent_accueil = true")
+      .joins(organisation: :rdvs)
+      .group(:agent_id)
+      .having("COUNT(rdvs.id) >= ?", SENSITIVE_RDV_THRESHOLD)
+      .pluck(:agent_id)
   end
 
   def sensitive_territory_admin_ids
     AgentTerritorialRole.where(territory_id: sensitive_territory_ids).pluck(:agent_id)
   end
 
+  # Un admin de territoire a accès à l'ensemble des organisations de son territoire,
+  # le volume est donc cumulé sur toutes les organisations du territoire.
   def sensitive_territory_ids
     Territory.joins(organisations: :rdvs)
       .group("territories.id")
-      .having("COUNT(rdvs.id) >= ?", SENSITIVE_TERRITORY_RDV_THRESHOLD)
+      .having("COUNT(rdvs.id) >= ?", SENSITIVE_RDV_THRESHOLD)
       .pluck(:id)
   end
 

--- a/spec/jobs/cron_job/refresh_agents_sensitive_account_job_spec.rb
+++ b/spec/jobs/cron_job/refresh_agents_sensitive_account_job_spec.rb
@@ -2,10 +2,74 @@ RSpec.describe CronJob::RefreshAgentsSensitiveAccountJob, type: :job do
   describe "#perform" do
     before do
       # Stub le seuil pour éviter de créer beaucoup de RDVs
-      stub_const("CronJob::RefreshAgentsSensitiveAccountJob::SENSITIVE_TERRITORY_RDV_THRESHOLD", 2)
+      stub_const("CronJob::RefreshAgentsSensitiveAccountJob::SENSITIVE_RDV_THRESHOLD", 2)
     end
 
-    it "met sensitive_account à true pour les admins de territoires avec beaucoup de RDVs" do
+    it "met sensitive_account à true pour un agent admin d'une organisation avec beaucoup de RDVs" do
+      organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation], sensitive_account: false)
+      create_list(:rdv, 3, organisation: organisation)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be true
+    end
+
+    it "met sensitive_account à true pour un agent accueil d'une organisation avec beaucoup de RDVs" do
+      organisation = create(:organisation)
+      agent = create(:agent, agent_accueil_role_in_organisations: [organisation], sensitive_account: false)
+      create_list(:rdv, 3, organisation: organisation)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be true
+    end
+
+    it "ne met pas sensitive_account à true pour un agent basic (non admin, non accueil) d'une organisation avec beaucoup de RDVs" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation], sensitive_account: false)
+      create_list(:rdv, 3, organisation: organisation)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be false
+    end
+
+    it "cumule le volume de RDVs sur plusieurs organisations dont l'agent est admin ou accueil" do
+      organisation_1 = create(:organisation)
+      organisation_2 = create(:organisation)
+      agent = create(:agent,
+                     admin_role_in_organisations: [organisation_1],
+                     agent_accueil_role_in_organisations: [organisation_2],
+                     sensitive_account: false)
+      create(:rdv, organisation: organisation_1)
+      create(:rdv, organisation: organisation_2)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be true
+    end
+
+    it "met sensitive_account à false pour un agent admin d'une organisation avec peu de RDVs" do
+      organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation], sensitive_account: true)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be false
+    end
+
+    it "ne modifie pas sensitive_account des agents sans rôle admin, accueil ou territorial" do
+      agent_with_sensitive = create(:agent, sensitive_account: true)
+      agent_without_sensitive = create(:agent, sensitive_account: false)
+
+      described_class.perform_now
+
+      expect(agent_with_sensitive.reload.sensitive_account).to be true
+      expect(agent_without_sensitive.reload.sensitive_account).to be false
+    end
+
+    it "met sensitive_account à true pour les admins de territoire dont une organisation a beaucoup de RDVs" do
       territory = create(:territory)
       organisation = create(:organisation, territory: territory)
       agent = create(:agent, role_in_territories: [territory], sensitive_account: false)
@@ -16,23 +80,26 @@ RSpec.describe CronJob::RefreshAgentsSensitiveAccountJob, type: :job do
       expect(agent.reload.sensitive_account).to be true
     end
 
-    it "met sensitive_account à false pour les admins de territoires avec peu de RDVs" do
+    it "cumule le volume de RDVs sur plusieurs organisations d'un même territoire pour un admin de territoire" do
+      territory = create(:territory)
+      organisation_1 = create(:organisation, territory: territory)
+      organisation_2 = create(:organisation, territory: territory)
+      agent = create(:agent, role_in_territories: [territory], sensitive_account: false)
+      create(:rdv, organisation: organisation_1)
+      create(:rdv, organisation: organisation_2)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be true
+    end
+
+    it "met sensitive_account à false pour les admins de territoire dont aucune organisation n'a beaucoup de RDVs" do
       territory = create(:territory)
       agent = create(:agent, role_in_territories: [territory], sensitive_account: true)
 
       described_class.perform_now
 
       expect(agent.reload.sensitive_account).to be false
-    end
-
-    it "ne modifie pas sensitive_account des agents non-admins de territoire" do
-      agent_with_sensitive = create(:agent, sensitive_account: true)
-      agent_without_sensitive = create(:agent, sensitive_account: false)
-
-      described_class.perform_now
-
-      expect(agent_with_sensitive.reload.sensitive_account).to be true
-      expect(agent_without_sensitive.reload.sensitive_account).to be false
     end
 
     it "met sensitive_account à true pour un agent admin d'une organisation rdv_insertion, quel que soit le nombre de RDVs" do


### PR DESCRIPTION
# Contexte

Le job `RefreshAgentsSensitiveAccountJob` (exécuté chaque nuit) détermine quels agents sont considérés comme ayant un compte sensible, ce qui déclenche une exigence de double authentification renforcée à la connexion.

Jusqu'ici, seuls les admins de territoire ayant accès à un volume important de RDV (≥ 5000) étaient concernés. Or les agents d'accueil disposent, au même titre que les admins d'organisation, d'une visibilité sur l'intégralité des RDV de leur organisation (cf. `Agent::RdvPolicy::Scope`), alors qu'ils n'étaient pas pris en compte par ce job. Un agent basic, lui, n'a qu'un accès restreint (ses propres RDV et ceux de son service), et n'a donc pas vocation à être concerné (pour le moment).

# Solution

- Élargissement du critère aux agents ayant un rôle **admin ou agent d'accueil** sur une ou plusieurs organisations (et plus uniquement les admins de territoire), en cumulant le volume de RDV sur l'ensemble des organisations où l'agent dispose d'un tel rôle. Un agent admin/accueil sur deux organisations de 3000 RDV chacune (soit 6000 au total) devient donc bien sensible, même si aucune des deux organisations ne dépasse individuellement le seuil.
- La même logique de cumul est conservée pour les admins de territoire, en sommant les RDV de toutes les organisations du territoire.
- Le critère lié aux admins d'organisations `rdv_insertion` (sensibles indépendamment du volume) est inchangé.
- Correction annexe : la remise à `false` de `sensitive_account` couvre désormais tous les agents évalués par un des critères (admin, accueil ou territorial), et non plus seulement les admins de territoire. Un agent ayant perdu son rôle admin sur une organisation `rdv_insertion` restait auparavant marqué comme sensible indéfiniment.
- Renommage de la constante `SENSITIVE_TERRITORY_RDV_THRESHOLD` en `SENSITIVE_RDV_THRESHOLD`, désormais utilisée pour les deux critères.
- Ajout de tests couvrant les nouveaux cas : rôle accueil, rôle basic non concerné, cumul multi-organisations et multi-territoire.
