### PR TITLE
Ajout d'un lien pour revenir à la prise de rendez-vous par intégration

### DIFF
--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -47,4 +47,7 @@ header.header.bg-white
             = render "layouts/lagaufre_button"
 
   = render "layouts/super_admin_sign_in_as_warning"
-  = render "layouts/meet_the_team_banner" unless @hide_meet_the_team_banner
+  - if RdvPlan.where(planning_agent: current_agent, rdv_id: nil).where("created_at > ?", 20.minutes.ago).any?
+    = render "layouts/rdv_plan_banner"
+  - else
+    = render "layouts/meet_the_team_banner" unless @hide_meet_the_team_banner

--- a/app/views/layouts/_rdv_plan_banner.html.slim
+++ b/app/views/layouts/_rdv_plan_banner.html.slim
@@ -1,0 +1,8 @@
+- rdv_plan = RdvPlan.where(planning_agent: current_agent, rdv_id: nil).order("created_at desc").first
+
+.fr-notice.fr-notice--info
+  .fr-notice__body
+    p.fr-mb-0.fr-ml-6w
+      span.fr-notice__desc
+        |> Vous avez commencé à prendre un rendez-vous pour #{rdv_plan.user.full_name} depuis #{rdv_plan.oauth_application.name}.
+        = link_to("Retourner à la préparation de ce rendez-vous", agents_rdv_plan_path(rdv_plan), class: "fr-btn fr-btn--tertiary")

--- a/spec/factories/rdv_plan.rb
+++ b/spec/factories/rdv_plan.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :rdv_plan do
     user { create(:user) }
     planning_agent { create(:agent) }
+    oauth_application { create(:oauth_application) }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
   end

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -231,4 +231,24 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
       expect(page).to have_content "Vous devez d'abord créer un motif de rendez-vous pour l'organisation CCAS de Montreuil"
     end
   end
+
+  describe "retour vers la prise de rendez-vous depuis l'interface principale" do
+    before do
+      create(:rdv_plan, planning_agent: agent, rdv_agent: agent, rdv: nil)
+    end
+
+    it "est possible via un lien dans un bandeau" do
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+
+      expect(page).to have_content("Vous avez commencé à prendre un rendez-vous")
+      click_on "Retourner à la préparation de ce rendez-vous"
+      expect(page).to have_content("Nouveau rendez-vous avec")
+    end
+
+    it "remplace le bandeau de rendez-vous d'accompagnement" do
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+
+      expect(page).not_to have_content("Besoin d'aide pour bien démarrer ?")
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Si un agent commence une prise de rendez-vous par intégration, puis va dans l'interface "classique" via le lien "Espace agent" ou autre, il n'y a aucun moyen de retrouver le rdv plan qui a été commencé.

C'est pas pratique du tout, et ça donne l'impression qu'il ne faut surtout pas se perdre pendant une prise de rendez-vous par intégration.

# Solution

S'il y a un rdv_plan inachevé qui a été modifié dans les 20 dernières minutes, on affiche ce bandeau :

<img width="1432" height="540" alt="Screenshot 2026-09-03 at 10 39 26" src="https://github.com/user-attachments/assets/1835b14b-8aa3-4484-bd93-6a78501f6a73" />

Pour éviter de surcharger l'interface, on cache le bandeau de rendez-vous d'accompagnement si on affiche ce bandeau.
