### PR TITLE
Reset session agent logout

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -74,9 +74,17 @@ class Agents::SessionsController < Devise::SessionsController
 
     sign_out(:agent)
 
+    # `sign_out` ne vide que les clés Warden internes de la session : les données applicatives qui y
+    # auraient été stockées (jetons ProConnect, etc.) survivraient sinon à la déconnexion, avec un
+    # risque de fuite entre agents sur un poste partagé. On vide donc la session dans son intégralité,
+    # sauf si un super admin a usurpé l'identité de cet agent (`session[:super_admin_signed_in_as_agent]`,
+    # cf `SuperAdmins::AgentsController#sign_in_as`) : les scopes `:agent` et `:super_admin` coexistent
+    # alors dans la même session, et un `reset_session` déconnecterait aussi le super admin.
+    reset_session unless session[:super_admin_signed_in_as_agent]
+
     # Si on redirige vers l'app cliente, on n'aura pas de render pendant lequel le flash s'affichera, donc on ne l'ajoute pas.
     if @oauth_client_app_post_logout_redirect_url
-      # On est obligés de modifier la session ici puisque l'appel à `sign_out(:agent)` a effacé la session
+      # On est obligés de modifier la session ici puisque l'appel à `sign_out(:agent)` (ou `reset_session` juste au-dessus) a effacé la session
       session[:post_logout_redirect_url] = @oauth_client_app_post_logout_redirect_url
     else
       set_flash_message!(:notice, :signed_out)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -329,6 +329,12 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
+  Warden::Manager.before_logout(scope: :agent) do |_user, auth, _opts|
+    next if auth.raw_session[:super_admin_signed_in_as_agent]
+
+    ActionDispatch::Request.new(auth.env).reset_session
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -329,12 +329,6 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
-  Warden::Manager.before_logout(scope: :agent) do |_user, auth, _opts|
-    next if auth.raw_session[:super_admin_signed_in_as_agent]
-
-    ActionDispatch::Request.new(auth.env).reset_session
-  end
-
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Agents::SessionsController do
         expect(response).to redirect_to(new_agent_session_path(pro_connect_required: agent.email))
         expect(session["warden.agent.key"]).to be_nil
       end
+
+      it "vide la session dans son intégralité" do
+        session[:some_unrelated_key] = "devrait disparaître"
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+        expect(session[:some_unrelated_key]).to be_nil
+      end
     end
 
     context "when the agent does not have a pro_connect_openid_sub" do
@@ -56,6 +62,30 @@ RSpec.describe Agents::SessionsController do
 
   describe "#destroy" do
     before { sign_in agent }
+
+    it "vide la session dans son intégralité" do
+      session[:some_unrelated_key] = "devrait disparaître"
+      get :destroy
+      expect(session[:some_unrelated_key]).to be_nil
+    end
+
+    context "quand l'agent est usurpé par un super admin" do
+      let(:super_admin) { create(:super_admin) }
+
+      before do
+        sign_in super_admin, scope: :super_admin
+        session[:super_admin_signed_in_as_agent] = true
+        session[:some_unrelated_key] = "devrait survivre"
+      end
+
+      it "ne déconnecte pas le super admin et laisse le reste de la session intact" do
+        get :destroy
+
+        expect(session["warden.user.super_admin.key"]).to be_present
+        expect(session[:some_unrelated_key]).to eq("devrait survivre")
+        expect(response).to redirect_to(super_admins_agents_path)
+      end
+    end
 
     context "when the agent was logged in with ProConnect" do
       stub_env_with(PRO_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2")

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe Agents::SessionsController do
         expect(response).to redirect_to(new_agent_session_path(pro_connect_required: agent.email))
         expect(session["warden.agent.key"]).to be_nil
       end
-
-      it "vide la session dans son intégralité" do
-        session[:some_unrelated_key] = "devrait disparaître"
-        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
-        expect(session[:some_unrelated_key]).to be_nil
-      end
     end
 
     context "when the agent does not have a pro_connect_openid_sub" do


### PR DESCRIPTION
Remplace #6659 

# Contexte

À la déconnexion d'un agent, `sign_out` ne vide que les clés internes utilisées par Warden/Devise pour l'authentification. Les autres données stockées en session (jetons ProConnect notamment) survivent donc à la déconnexion. Sur un poste partagé entre plusieurs agents, ces données peuvent se retrouver accessibles à l'agent suivant qui se connecte depuis le même navigateur.

# Solution

À la déconnexion d'un agent (`Agents::SessionsController#destroy`), la session est désormais vidée dans son intégralité via `reset_session`, en complément du `sign_out` existant.

Un seul cas est exclu de ce nettoyage complet : lorsqu'un super admin a usurpé l'identité de l'agent (`session[:super_admin_signed_in_as_agent]`, cf. `SuperAdmins::AgentsController#sign_in_as`). Dans ce cas, les scopes `:agent` et `:super_admin` coexistent dans la même session, et un `reset_session` déconnecterait aussi le super admin par la même occasion — le comportement reste donc inchangé pour ce cas précis.

Des tests couvrent les deux scénarios : nettoyage complet de la session en déconnexion normale, et préservation de la session du super admin en cas d'usurpation d'identité.
