### PR TITLE
Ne pas permettre de changer le motif pour un lien de réservation direct d'un motif

### DIFF
--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -26,7 +26,7 @@ class RedirectController < ApplicationController
   def prendre_rdv_path_for(rdv, token)
     prendre_rdv_path(
       departement: rdv.organisation.departement_number,
-      motif_name_with_location_type: rdv.motif.name_with_location_type,
+      preselected_motif: rdv.motif&.public_link_id,
       public_link_organisation_id: rdv.organisation_id,
       lieu_id: rdv.lieu_id,
       address: rdv.address,

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -140,7 +140,7 @@ class SearchController < ApplicationController
       redirect_to prendre_rdv_path({
         public_link_organisation_id: organisation.id,
         departement: organisation.territory.departement_number,
-        motif_id: motif&.id,
+        preselected_motif: motif&.public_link_id,
         prescripteur:,
       }.compact)
     else
@@ -168,7 +168,7 @@ class SearchController < ApplicationController
     params.permit(
       *WebSearchContext::ADDRESS_SELECTION_PARAMS,
       *WebSearchContext::USER_CHOICE_PARAMS,
-      :motif_category_short_name, :date, :public_link_organisation_id, :prescripteur,
+      :motif_category_short_name, :date, :public_link_organisation_id, :prescripteur, :preselected_motif,
       organisation_ids: [], referent_ids: [], external_organisation_ids: []
     ).to_h.deep_symbolize_keys
   end

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -5,7 +5,7 @@ class Users::RdvWizardStepsController < UserAuthController
   EXTRA_PERMITTED_PARAMS = [
     *WebSearchContext::ADDRESS_SELECTION_PARAMS,
     :lieu_id, :where, :rdv_collectif_id, :user_selected_organisation_id,
-    :public_link_organisation_id, :duration, :ants_pre_demandes_count,
+    :public_link_organisation_id, :preselected_motif, :duration, :ants_pre_demandes_count,
     { organisation_ids: [], referent_ids: [], external_organisation_ids: [] },
   ].freeze
 

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -2,6 +2,7 @@ class Users::RdvWizardStepsController < UserAuthController
   layout "application_base"
 
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
+
   EXTRA_PERMITTED_PARAMS = [
     *WebSearchContext::ADDRESS_SELECTION_PARAMS,
     :lieu_id, :where, :rdv_collectif_id, :user_selected_organisation_id,

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -67,6 +67,7 @@ module SearchContextHelper
     [
       *WebSearchContext::ADDRESS_SELECTION_PARAMS,
       :public_link_organisation_id,
+      :preselected_motif,
       :prescripteur,
       :duration,
       :current_organisation,

--- a/app/services/users/rdv_builder.rb
+++ b/app/services/users/rdv_builder.rb
@@ -60,7 +60,7 @@ class Users::RdvBuilder
     }.merge(
       @attributes.slice(
         *WebSearchContext::ADDRESS_SELECTION_PARAMS,
-        :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
+        :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id, :preselected_motif,
         :referent_ids, :external_organisation_ids, :duration, :ants_pre_demandes_count
       )
     )

--- a/app/services/users/rdv_builder.rb
+++ b/app/services/users/rdv_builder.rb
@@ -67,7 +67,7 @@ class Users::RdvBuilder
   end
 
   def to_query_for_search_redirection
-    q = @attributes.slice(:address, :city_code, :street_ban_id, :departement, :organisation_ids, :ants_pre_demandes_count).merge(
+    q = @attributes.slice(:address, :city_code, :street_ban_id, :departement, :organisation_ids, :ants_pre_demandes_count, :preselected_motif).merge(
       service: motif&.service_id,
       motif_name_with_location_type: motif&.name_with_location_type
     )

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -15,6 +15,7 @@ class WebSearchContext < SearchContext
     @external_organisation_ids = query_params[:external_organisation_ids]
     @referent_ids = query_params[:referent_ids]
     @prescripteur = query_params[:prescripteur]
+    @preselected_motif_public_link_id = query_params[:preselected_motif]
 
     # Address selection:
     @latitude = query_params[:latitude]
@@ -60,6 +61,7 @@ class WebSearchContext < SearchContext
     motifs = motifs.where(service_id: @service_id) if @service_id.present?
     motifs = motifs.where(organisation_id: organisation_id) if organisation_id.present?
     motifs = motifs.where(id: @motif_id) if @motif_id.present?
+    motifs = motifs.where(public_link_id: @preselected_motif_public_link_id) if @preselected_motif_public_link_id.present?
     motifs
   end
 
@@ -71,7 +73,8 @@ class WebSearchContext < SearchContext
 
   def motif_param_present?
     @motif_id.present? ||
-      @motif_name_with_location_type.present?
+      @motif_name_with_location_type.present? ||
+      @preselected_motif_public_link_id.present?
   end
 
   def matching_motifs

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -5,8 +5,9 @@
         .col
           | Motif :&nbsp;
           = context.first_matching_motif.name
-        .col-auto
-          = dsfr_link_to "Modifier", path_to_service_selection(params), title: "Modifier le motif"
+        - if context.query_params["preselected_motif"].blank?
+          .col-auto
+            = dsfr_link_to "Modifier", path_to_service_selection(params), title: "Modifier le motif"
     - case context.first_matching_motif.location_type
     - when Motif.location_types[:phone]
       li.list-group-item

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -5,7 +5,7 @@
         .col
           | Motif :&nbsp;
           = context.first_matching_motif.name
-        - if context.query_params["preselected_motif"].blank?
+        - if context.query_params[:preselected_motif].blank?
           .col-auto
             = dsfr_link_to "Modifier", path_to_service_selection(params), title: "Modifier le motif"
     - case context.first_matching_motif.location_type

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -4,8 +4,9 @@ ul.list-group.list-group-flush.fr-mt-0
       .col
         | Motif :&nbsp;
         = rdv_wizard.motif.name
-      .col-auto
-        = dsfr_link_to "Modifier", path_to_motif_selection(rdv_wizard.params_to_selections), title: "Modifier le motif"
+      - if rdv_wizard.params_to_selections[:preselected_motif].blank?
+        .col-auto
+          = dsfr_link_to "Modifier", path_to_motif_selection(rdv_wizard.params_to_selections), title: "Modifier le motif"
 
   - case rdv_wizard.motif.location_type
   - when Motif.location_types[:phone]

--- a/spec/features/prescripteurs/booking_from_a_motif_link_spec.rb
+++ b/spec/features/prescripteurs/booking_from_a_motif_link_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe "Prescription depuis un lien de motif" do
     expect(page).to have_content("Prenez rendez-vous en ligne") # On se fait rediriger vers la prise de rendez-vous en ligne
 
     # Le lien a bien le paramètre de prescription
-    expect(page.current_url).to end_with("/prendre_rdv?departement=01&motif_id=#{motif.id}&prescripteur=1&public_link_organisation_id=#{motif.organisation_id}")
+    expect(page.current_url).to end_with("/prendre_rdv?departement=01&prescripteur=1&preselected_motif=#{motif.public_link_id}&public_link_organisation_id=#{motif.organisation_id}")
   end
 end

--- a/spec/features/users/prise_de_rdv/depuis_lien_du_motif_spec.rb
+++ b/spec/features/users/prise_de_rdv/depuis_lien_du_motif_spec.rb
@@ -1,13 +1,12 @@
 RSpec.describe "Prise de rendez-vous depuis le lien d'un motif" do
   let(:organisation) { create(:organisation) }
-  let!(:motif) do
-    create(:motif, bookable_by: :everyone, organisation:)
-  end
+  let!(:motif) { create(:motif, bookable_by: :everyone, organisation:) }
+  let!(:other_motif) { create(:motif, bookable_by: :everyone, organisation:) }
   let(:lieu) { create(:lieu, organisation:) }
 
   before do
     travel_to(Time.zone.parse("2022-09-12 15:00:00"))
-    create(:plage_ouverture, motifs: [motif], lieu:)
+    create(:plage_ouverture, motifs: [motif, other_motif], lieu:)
   end
 
   it "permet une prise de rendez-vous mais ne permet pas de changer de motif" do

--- a/spec/features/users/prise_de_rdv/depuis_lien_du_motif_spec.rb
+++ b/spec/features/users/prise_de_rdv/depuis_lien_du_motif_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe "Prise de rendez-vous depuis le lien d'un motif" do
+  let(:organisation) { create(:organisation) }
+  let!(:motif) do
+    create(:motif, bookable_by: :everyone, organisation:)
+  end
+  let(:lieu) { create(:lieu, organisation:) }
+
+  before do
+    travel_to(Time.zone.parse("2022-09-12 15:00:00"))
+    create(:plage_ouverture, motifs: [motif], lieu:)
+  end
+
+  it "permet une prise de rendez-vous mais ne permet pas de changer de motif" do
+    visit public_link_to_motif_path(public_link_id: motif.public_link_id, motif_slug: motif.slug)
+
+    expect(page).to have_content(motif.name)
+    expect(page).not_to have_content("Modifier")
+
+    click_on(lieu.name)
+
+    # On a un lien de modification pour le lieu
+    expect(page).to have_content("Modifier", count: 1)
+
+    click_on("08:00")
+
+    # On a un lien de modification pour le lieu et un pour l'horaire
+    expect(page).to have_content("Modifier", count: 2)
+
+    fill_in "Prénom", with: "Francis"
+    fill_in "Nom", with: "Factice"
+    fill_in "Adresse email", with: "francis@factice.org"
+    click_on "Recevoir un code de connexion"
+
+    expect(page).to have_content("Saisie du code de connexion")
+
+    # Ici aussi on a un lien de modification pour le lieu et un pour l'horaire, mais pas de lien pour changer le motif
+    expect(page).to have_content("Modifier", count: 2)
+
+    fill_in "Code à 6 chiffres", with: LoginCode.last.code
+    click_on "Valider"
+
+    expect(page).to have_content("Confirmez votre rendez-vous")
+
+    # Ici aussi on a un lien de modification pour le lieu et un pour l'horaire, mais pas de lien pour changer le motif
+    expect(page).to have_content("Modifier", count: 2)
+
+    # On change le lieu
+    click_on "Modifier", match: :first
+
+    # On n'affiche toujours pas de lien pour changer le motif
+    expect(page).not_to have_content("Modifier")
+  end
+end

--- a/spec/form_models/users/rdv_builder_spec.rb
+++ b/spec/form_models/users/rdv_builder_spec.rb
@@ -147,4 +147,14 @@ RSpec.describe Users::RdvBuilder do
       expect(described_class.new(user_for_rdv, attributes).rdv).to eq(rdv)
     end
   end
+
+  describe "#to_query_for_search_redirection" do
+    context "en utilisant le paramètre preselected_motif" do
+      it "garde le paramètre" do
+        rdv_builder = described_class.new(user, attributes.merge(preselected_motif: motif.public_link_id))
+        query_params = rdv_builder.to_query_for_search_redirection
+        expect(query_params[:preselected_motif]).to eq motif.public_link_id
+      end
+    end
+  end
 end

--- a/spec/requests/redirect_controller_spec.rb
+++ b/spec/requests/redirect_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "RedirectController#reprendre_rdv_from_participation_invitation_t
         expect(response).to redirect_to(
           prendre_rdv_path(
             departement: organisation.departement_number,
-            motif_name_with_location_type: motif.name_with_location_type,
+            preselected_motif: motif.public_link_id,
             public_link_organisation_id: organisation.id,
             lieu_id: lieu.id,
             address: rdv.address,


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1229" height="364" alt="Screenshot 2026-09-07 at 11 26 06" src="https://github.com/user-attachments/assets/54a3da13-fd34-4bc4-9496-db811a6f8ada" />|<img width="1219" height="362" alt="Screenshot 2026-09-07 at 11 25 36" src="https://github.com/user-attachments/assets/79d706fa-ba64-4b9f-ab29-f2b6b094e76d" />



# Contexte

Les liens de réservation direct pour un motif actuellement à l'usager de changer de motif lors de sa prise de rendez-vous. Cela pose problème à certaines organisation qui veulent pouvoir envoyer ces liens et éviter que des usagers "trichent" en prenant rendez-vous pour un autre motif.

# Solution

On supprime donc le lien pour changer de motif lorsque la prise de rendez-vous se fait avec un lien direct vers un motif.

Ça reste possible de changer le motif en modifiant les paramètres de l'url, mais on compte sur la plupart des usagers pour ne pas se lancer dans ce changer de manip.

On ajoute donc un paramètre `preselected_motif` dans le search_context, ce qui permet de le distinguer du motif choisit pas l'usager. Il fonctionne de manière similaire au `public_link_organisation_id`.
On commence à avoir beaucoup de paramètres dans ces urls qui sont mises la session au moment de la redirection vers le login. Cette session est stockée dans un cookie encrypté, donc j'ai nommé le paramètre `preselected_motif` plûtot que `preselected_motif_public_link_id` pour gagner quelques caractères et éviter les overflow de cookie.

On utilise le `motif.public_link_id` qui a l'avantage de ne pas être énumérable.

On manque de bonnes abstractions dans cette partie du code, donc je me suis suis retrouvé à ajouter une spec d'intégration pour naviguer entre les différents états possibles.
