### PR TITLE
File d'attente : supprime l'oracle d'existence sur le paramètre id

### DIFF
--- a/app/controllers/users/file_attentes_controller.rb
+++ b/app/controllers/users/file_attentes_controller.rb
@@ -16,7 +16,7 @@ class Users::FileAttentesController < UserAuthController
 
   def create_or_delete
     fa = if file_attente_params[:id].present?
-           FileAttente.find(file_attente_params[:id])
+           FileAttente.find_or_initialize_by(id: file_attente_params[:id])
          else
            FileAttente.where(rdv_id: file_attente_params[:rdv_id], user_id: file_attente_params[:user_id])
              .first_or_initialize

--- a/spec/controllers/users/file_attentes_controller_spec.rb
+++ b/spec/controllers/users/file_attentes_controller_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe Users::FileAttentesController, type: :controller do
       end
     end
 
+    context "quand l'id fourni ne correspond à aucune file d'attente" do
+      let!(:own_file_attente) { create(:file_attente, rdv: rdv, user: user) }
+
+      it "ne touche à aucune file d'attente et redirige (pas d'oracle d'existence)" do
+        expect do
+          post :create_or_delete, params: { file_attente: { id: 0 } }
+        end.not_to change(FileAttente, :count)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
     context "quand le current_user n'a aucun lien avec la file d'attente ciblée" do
       let(:other_user) { create(:user) }
       let!(:other_rdv) { create(:rdv, users: [other_user]) }


### PR DESCRIPTION
# Contexte

Ceci nous a été remonté comme une faille de sécurité. C'est reproductible mais la gravité est très limitée. On corrige quand même

---

`Users::FileAttentesController#create_or_delete` éxecute : `FileAttente.find(file_attente_params[:id])`

Selon l’`id` passé par le client, la réponse diffère :

- `id` inexistant → `ActiveRecord::RecordNotFound` → **404**
- `id` existant mais n'appartenant pas au `current_user` → `Pundit::NotAuthorizedError`
  → **redirection** (302)

Cette différence de réponse est un oracle d'existence : en énumérant des `id`,
on peut reconstituer la progression de la séquence `file_attentes.id`, donc le
volume approximatif d'inscriptions en liste d'attente sur la plateforme et leur
cadence. gravité faible, pas de données personnelles exposées.