### PR TITLE
Adresse domicile reprendre rdv

### DIFF
--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -29,7 +29,6 @@ class RedirectController < ApplicationController
       motif_name_with_location_type: rdv.motif.name_with_location_type,
       public_link_organisation_id: rdv.organisation_id,
       lieu_id: rdv.lieu_id,
-      address: rdv.address,
       invitation_token: token
     )
   end

--- a/spec/requests/redirect_controller_spec.rb
+++ b/spec/requests/redirect_controller_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe "RedirectController#reprendre_rdv_from_participation_invitation_t
             motif_name_with_location_type: motif.name_with_location_type,
             public_link_organisation_id: organisation.id,
             lieu_id: lieu.id,
-            address: rdv.address,
             invitation_token: token
           )
         )
@@ -30,6 +29,20 @@ RSpec.describe "RedirectController#reprendre_rdv_from_participation_invitation_t
         expect(response).to redirect_to(root_path)
         expect(flash[:error]).to eq(I18n.t("devise.invitations.invitation_token_invalid"))
       end
+    end
+
+    it "ne divulgue pas l'adresse personnelle du bénéficiaire d'un RDV à domicile dans la redirection" do
+      organisation = create(:organisation)
+      motif = create(:motif, :at_home, organisation:, bookable_by: :everyone)
+      user = create(:user, address: "12 rue Secrète, 75001 Paris")
+      rdv = create(:rdv, organisation:, motif:, lieu: nil, users: [user])
+      token = rdv.participations.first.restricted_auth_token
+
+      get "/prdv", params: { tkn: token }
+
+      expect(response).to have_http_status(:found)
+      expect(response.headers["Location"]).not_to include("Secr")
+      expect(response.headers["Location"]).not_to include(CGI.escape("12 rue Secrète, 75001 Paris"))
     end
   end
 end


### PR DESCRIPTION
# Contexte

Le lien court « reprendre RDV » envoyé par email et SMS après l'annulation d'un rendez-vous (`GET /prdv?tkn=<jeton>`) est servi par `RedirectController#reprendre_rdv_from_participation_invitation_token`, sans aucune authentification.

Il répond par une redirection 302 vers `/prendre_rdv`, en recopiant `rdv.address` dans le paramètre `address` de l'URL, donc dans l'en-tête `Location`.
Pour un motif à domicile, `Rdv#address` renvoie l'adresse de l'usager.

Conséquences : en interceptant un jeton de participation valide on peut récupérer l'adresse d'un usager



# Solution

**Ne plus passer `address` dans `RedirectController#prendre_rdv_path_for`**

Ce paramètre ne sert qu'à préremplir le champ texte de l'étape de sélection d'adresse. Or cette étape n'est façon jamais atteinte ici, la redirection fournissant toujours `departement` et `public_link_organisation_id`

Le parcours équivalent pour un usager connecté (`Users::ParticipationsController#prendre_rdv_path_for_current_rdv`) construit déjà la même URL sans `address` et fonctionne.

# Vérifications manuelles 

## Reproduction 

1. Créer un motif à domicile réservable en ligne, un usager avec une adresse renseignée, et un RDV associé
2. Récupérer `rdv.participations.first.restricted_auth_token`
3. Sans être connecté : `curl -sI "https://<hote>/prdv?tkn=<JETON>" | grep -i location`
4. L'en-tête `Location` contient `address=<adresse+personnelle+du+bénéficiaire>`.

On peut aussi reproduire en annulant le RDV à l'initiative du service en tant qu'agent et en suivant le lien « Reprendre RDV » du mail d'annulation reçu par l'usager. Il faut bien surveiller les requêtes à ce moment car on se retrouve sur la page de saisie des initiales mais l'URL de redirection contenait l'adresse de l'usager

Une fois passée l'étape de validation du nom de famille on arrive sur la sélection de créneau et on a un lien pour revenir à la sélection de motif : 

<img width="786" height="1704" alt="image" src="https://github.com/user-attachments/assets/e66ce478-60dc-4193-ae4b-d0292e8fab70" />

Ce lien marche toujours après cette PR, pas de changement. 

# Hors scope

Il y a plusieurs incohérences de parcours pour les RDV a domicile sur la saisie d'adresse par les agents et les usagers, je les ai notées ici #6490 
