### PR TITLE
CI: corrige la croissance exponentielle du cache runtime log des specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
           else
             RUNTIME_LOG_ARGS="--group-by filesize"
           fi
+          # d'autres options sont passées via .rspec_parallel
           RAILS_ENV=test bundle exec parallel_test spec --type rspec --pattern 'spec/(?!features/autodoc)' -n 16 --only-group ${{ matrix.only_group }} $RUNTIME_LOG_ARGS
         env:
           HOST: http://example.com
@@ -251,7 +252,8 @@ jobs:
       - name: Merge runtime logs
         run: |
           mkdir -p tmp
-          cat artifacts/*/rspec-runtime-*.log > tmp/rspec-runtime-merged.log 2>/dev/null || true
+          # un log par shard : rspec-runtime-${CI_SHARD_NAME}.log (cf .rspec_parallel), CI_SHARD_NAME = matrix.name = specs_1..4
+          cat artifacts/*/rspec-runtime-specs_*.log > tmp/rspec-runtime-merged.log 2>/dev/null || true
       - name: Save merged runtime log for the next runs
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:


### PR DESCRIPTION
Le problème de nos jobs canceled sur les runners GH actions venait d'un fichier de runtime log qui grossissait exponentiellement. 

Le process actuel : 
- on récupère le fichier `runtime_log_merged.log` de toutes les specs sur le cache de la CI
- on lance des shards qui utilisent chacun ce fichier `_merged` mais ne lancent qu'une partie des specs
- dans un job final post tous les shards, on récupère tous les petits fichiers de runtime des shards, on créé un grand fichier `_merged.log` et on l'uploade dans le cache pour les runs futurs.

Le problème était à la dernière étape. le glob pattern récupérait aussi le fichier `_merged.log` précédent en plus des petits fichiers de log de chaque shard effectivement lancé. la croissance était donc exponentielle. 