### PR TITLE
CI: rapatrie les options depuis .rspec_parallel dans ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,14 +225,13 @@ jobs:
             -n 16 --only-group ${{ matrix.only_group }} \
             $RUNTIME_LOG_ARGS \
             -- \
-            --format ParallelTests::RSpec::RuntimeLogger --out tmp/rspec-runtime-${CI_SHARD_NAME}.log \
+            --format ParallelTests::RSpec::RuntimeLogger --out tmp/rspec-runtime-${{ matrix.name }}.log \
             --format ParallelTests::RSpec::SummaryLogger --out tmp/rspec-spec_summary.log \
             --format ParallelTests::RSpec::FailuresLogger --out tmp/rspec-failing_specs.log \
             -- \
             spec
         env:
           HOST: http://example.com
-          CI_SHARD_NAME: ${{ matrix.name }}
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
           POSTGRES_USER: lapin_test
@@ -261,7 +260,7 @@ jobs:
       - name: Merge runtime logs
         run: |
           mkdir -p tmp
-          # un log par shard : rspec-runtime-${CI_SHARD_NAME}.log, CI_SHARD_NAME = matrix.name = `specs_1` etc
+          # un log par shard : rspec-runtime-<matrix.name>.log, ex. rspec-runtime-specs_1.log
           cat artifacts/*/rspec-runtime-specs_*.log > tmp/rspec-runtime-merged.log 2>/dev/null || true
       - name: Save merged runtime log for the next runs
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,8 +219,17 @@ jobs:
           else
             RUNTIME_LOG_ARGS="--group-by filesize"
           fi
-          # d'autres options sont passées via .rspec_parallel
-          RAILS_ENV=test bundle exec parallel_test spec --type rspec --pattern 'spec/(?!features/autodoc)' -n 16 --only-group ${{ matrix.only_group }} $RUNTIME_LOG_ARGS
+          # syntaxe `parallel_test <options> -- <options rspec> -- <fichiers>` (+ options héritées de .rspec)
+          RAILS_ENV=test bundle exec parallel_test --type rspec \
+            --pattern 'spec/(?!features/autodoc)' \
+            -n 16 --only-group ${{ matrix.only_group }} \
+            $RUNTIME_LOG_ARGS \
+            -- \
+            --format ParallelTests::RSpec::RuntimeLogger --out tmp/rspec-runtime-${CI_SHARD_NAME}.log \
+            --format ParallelTests::RSpec::SummaryLogger --out tmp/rspec-spec_summary.log \
+            --format ParallelTests::RSpec::FailuresLogger --out tmp/rspec-failing_specs.log \
+            -- \
+            spec
         env:
           HOST: http://example.com
           CI_SHARD_NAME: ${{ matrix.name }}
@@ -252,7 +261,7 @@ jobs:
       - name: Merge runtime logs
         run: |
           mkdir -p tmp
-          # un log par shard : rspec-runtime-${CI_SHARD_NAME}.log (cf .rspec_parallel), CI_SHARD_NAME = matrix.name = specs_1..4
+          # un log par shard : rspec-runtime-${CI_SHARD_NAME}.log, CI_SHARD_NAME = matrix.name = `specs_1` etc
           cat artifacts/*/rspec-runtime-specs_*.log > tmp/rspec-runtime-merged.log 2>/dev/null || true
       - name: Save merged runtime log for the next runs
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,8 +1,0 @@
---color
---order rand
---require rails_helper
---format progress
---format ParallelTests::RSpec::RuntimeLogger --out tmp/rspec-runtime-<%= ENV.fetch("CI_SHARD_NAME", "current") %>.log
---format ParallelTests::RSpec::SummaryLogger --out tmp/rspec-spec_summary.log
---format ParallelTests::RSpec::FailuresLogger --out tmp/rspec-failing_specs.log
---format RspecJunitFormatter --out tmp/rspec-<%= ENV.fetch("TEST_ENV_NUMBER", "1") %>.xml

--- a/Gemfile
+++ b/Gemfile
@@ -234,8 +234,6 @@ group :test do
   gem "parallel_tests"
   # RSpec for Rails
   gem "rspec-rails"
-  # RSpec JUnit XML formatter
-  gem "rspec_junit_formatter", require: false
   # Extracting `assigns` and `assert_template` from ActionDispatch.
   gem "rails-controller-testing"
   # An OpenAPI-based (formerly called Swagger) DSL for rspec-rails & accompanying rake task for generating OpenAPI specification files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,8 +629,6 @@ GEM
     rspec-support (3.13.2)
     rspec-wait (1.0.1)
       rspec (>= 3.4)
-    rspec_junit_formatter (0.6.0)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rswag-api (2.16.0)
       activesupport (>= 5.2, < 8.1)
       railties (>= 5.2, < 8.1)
@@ -853,7 +851,6 @@ DEPENDENCIES
   redis-namespace
   rspec-rails
   rspec-wait
-  rspec_junit_formatter
   rswag-api
   rswag-specs
   rswag-ui
@@ -1105,7 +1102,6 @@ CHECKSUMS
   rspec-rails (8.0.2) sha256=113139a53f5d068d4f48d1c29ad5f982013ed9b0daa69d7f7b266eda5d433ace
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
   rspec-wait (1.0.1) sha256=50ce9cc7cd20b8bb67b95a4ed56b59a16d4af7e86ae91b28dbf20eeaa2481d1f
-  rspec_junit_formatter (0.6.0) sha256=40dde674e6ae4e6cc0ff560da25497677e34fefd2338cc467a8972f602b62b15
   rswag-api (2.16.0) sha256=b653f7bd92e98be18b01ab4525d88950d7b0960e293a99f856b9efcee3ae6074
   rswag-specs (2.16.0) sha256=8ba26085c408b0bd2ed21dc8015c80f417c7d34c63720ab7133c2549b5bd2a91
   rswag-ui (2.16.0) sha256=a1f49e927dceda92e6e6e7c1000f1e217ee66c565f69e28131dc98b33cd3a04f


### PR DESCRIPTION
suggestion de Victor 👍 

- suppression des options redondantes par rapport au `.rspec` : `--color --order rand --require rails_helper --format progress`
- meilleure lisibilité avec tout inliné
- retrait de RspecJunitFormatter qui n'est plus utilisé
- on n'utilise pas ou peu rspec parallel en local et ces options ne sont utiles que pour la CI pour l'instant je pense