### PR TITLE
Permettre aux agents de voir les disponibilités à + de 6 mois

### DIFF
--- a/app/services/creneaux_search/for_agent.rb
+++ b/app/services/creneaux_search/for_agent.rb
@@ -10,7 +10,7 @@ class CreneauxSearch::ForAgent
   end
 
   def next_availability(lieu = nil)
-    CreneauxSearch::NextAvailability.find(@form.motif, lieu, all_agents, from: @form.date_range.first)
+    CreneauxSearch::NextAvailability.find(@form.motif, lieu, all_agents, from: @form.date_range.first, to: 1.year.from_now)
   end
 
   def build_result


### PR DESCRIPTION
# Contexte

Suite à un message d’un agent sur Zammad, je me suis rendu compte du problème suivant. 
Si je suis agent, que je clique sur « Trouver un RDV », mais que toutes les plages d’ouvertures sont pleines pour les 6 prochains mois, je vois ce message : 

<img width="715" height="77" alt="image" src="https://github.com/user-attachments/assets/c9a4ec59-16d7-4b55-8983-3bd14943e6eb" />

Cela s’explique, car dans le `CreneauxSearch::NextAvailability` nous avons une valeur pour `to` à 6 mois quand la valeur n’est pas définie.

# Solution

Je propose donc de permettre aux agents de voir les créneaux disponibles jusqu’à un an à l’avance, ce qui permettra d’afficher ceci 

<img width="471" height="249" alt="image" src="https://github.com/user-attachments/assets/322d1fcd-c22d-4f49-b01e-29fdc5b7d2af" />

