### PR TITLE
Correction du bouton de déconnexion Super Admin

### DIFF
--- a/app/views/super_admins/application/_navigation.html.erb
+++ b/app/views/super_admins/application/_navigation.html.erb
@@ -8,7 +8,7 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation">
-  <%= link_to "Se déconnecter", super_admins_sign_out_path, method: :delete, class: "navigation__link" %>
+  <%= button_to "Se déconnecter", super_admins_sign_out_path, method: :delete, class: "navigation__link" %>
 
   <hr />
   <% Administrate::Namespace.new(namespace).resources_with_index_route.excluding("territory_creation_requests", "accounts_for_crm").each do |resource| %>

--- a/spec/features/super_admin/can_search_user_spec.rb
+++ b/spec/features/super_admin/can_search_user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Un super admin peut chercher un utilisateur", js: true do
     field = find_field("search")
     field.set(user.email)
     page.execute_script <<-JS
-      var form = document.querySelector('form');
+      var form = document.querySelector('form.search');
       form.requestSubmit();
     JS
 
@@ -26,7 +26,7 @@ RSpec.describe "Un super admin peut chercher un utilisateur", js: true do
     field = find_field("search")
     field.set("061122")
     page.execute_script <<-JS
-      var form = document.querySelector('form');
+      var form = document.querySelector('form.search');
       form.requestSubmit();
     JS
 


### PR DESCRIPTION
# Contexte

En se déconnectant du super admin via le bouton "Se déconnecter", l'utilisateur était redirigé vers une page 404.

Le lien de déconnexion utilisait `link_to ..., method: :delete`, une syntaxe qui repose sur du JavaScript (Rails-UJS ou Turbo Drive) pour transformer le clic en une requête DELETE. Or, sur les pages super admin, Turbo Drive est explicitement désactivé (`app/javascript/super_admin.js`) et Rails-UJS n'est pas chargé du tout. Le clic déclenchait donc une navigation classique en GET vers `/super_admins/sign_out`, route qui n'existe qu'en DELETE, d'où le 404.

# Solution

Remplacement du `link_to` par un `button_to`, qui génère un vrai formulaire HTML soumis en DELETE sans dépendre d'aucun JavaScript. Le bouton reste sur le même chemin (`super_admins_sign_out_path`) et conserve la classe `navigation__link`.