### PR TITLE
Augmenter la RAM du container `jobs` en review app

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -78,7 +78,7 @@
     },
     "jobs": {
       "amount": 0,
-      "size": "S"
+      "size": "M"
     }
   }
 }


### PR DESCRIPTION
Contexte : Scalingo commence à kill les containers qui dépassent les limites mémoire.

https://scalingo.com/fr/blog/clearer-memory-limits-for-application-containers

Le coût du passage de S (256 MB) à M (512 MB) est minime car :
- ce worker reste désactivé par défaut
- le worker M coûte 17 € par mois

On est donc à environ 2 euros pour 3 jours de job worker review app.