### PR TITLE
retirer le sentry cron monitor sur le job de file d'attente

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -24,8 +24,6 @@ class CronJob < ApplicationJob
   end
 
   class FileAttenteJob < CronJob
-    include MonitorConcern
-
     queue_as :latency_30s
 
     def perform


### PR DESCRIPTION
# Contexte

Discuté en point tech. Check introduit dans https://github.com/betagouv/rdv-service-public/pull/5409 . on voit les [cron monitor sur sentry ici](https://sentry.incubateur.net/organizations/betagouv/insights/crons/?environment=production&statsPeriod=7d)

Ce job remonte relativement souvent comme en erreur et nous génère du bruit car généralement il finit par passer rapidement après. 

# Solution

On pense qu'il vaut mieux arrêter de surveiller le CRON de ce job :
- C'est loin d’être le plus critique de notre appli
- C'est le plus fréquent ou presque (toutes les 10 minutes) donc les risques qu'un de ces jobs ne passent pas est mathématiquement plus élevé et la probabilité que le suivant corrige le problème sans trop d'impact aussi

Je proposerais peut-être de commencer à monitorer d'autres cron job dans une autre PR