### PR TITLE
Exploration de l'ajout d'un cop de linter pour les authorize autour des updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ plugins:
   - rubocop-rspec
   - rubocop-rails
 
+require:
+  - ./lib/rubocop/cop/rdv_service_public/pundit_authorize_stale_after_mutation.rb
+
 AllCops:
   Exclude:
     - "vendor/bundle/**/*"
@@ -330,3 +333,8 @@ RSpec/PredicateMatcher:
 
 Rails/RedundantPresenceValidationOnBelongsTo:
   Enabled: false
+
+RdvServicePublic/PunditAuthorizeStaleAfterMutation:
+  Enabled: true
+  Include:
+    - "app/controllers/**/*.rb"

--- a/app/controllers/admin/agent_intervenants_controller.rb
+++ b/app/controllers/admin/agent_intervenants_controller.rb
@@ -7,7 +7,9 @@ class Admin::AgentIntervenantsController < AgentAuthController
 
     agent_role = @agent.roles.find_by(organisation: current_organisation)
 
-    if agent_role.intervenant? && @agent.update(last_name: params[:agent][:last_name])
+    # Seul `last_name` est modifié, ce qui n'affecte pas `current_agent_or_admin_in_record_organisation?`
+    # (basé sur l'identité de l'agent et son organisation, pas sur son nom).
+    if agent_role.intervenant? && @agent.update(last_name: params[:agent][:last_name]) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       flash[:success] = "Intervenant modifié avec succès."
 
       redirect_to admin_organisation_agents_path(current_organisation)

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -50,7 +50,9 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
   def update_user_type
     authorize(@organisation, :update?, policy_class: Agent::OrganisationPolicy)
 
-    if @organisation.update(permitted_params)
+    # `permitted_params` ne touche que les modes d'authentification à la prise de RDV en ligne,
+    # ce qui n'affecte pas `admin_in_organisation?`.
+    if @organisation.update(permitted_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       flash[:success] = "Modes d'authentification mis à jour"
       redirect_to admin_organisation_online_booking_path(@organisation)
     else

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -23,7 +23,8 @@ class Admin::OrganisationsController < AgentAuthController
   def update
     authorize(@organisation, policy_class: Agent::OrganisationPolicy)
 
-    if @organisation.update(organisation_params)
+    # `organisation_params` (name/horaires/phone_number/website/email) n'affecte pas `admin_in_organisation?`.
+    if @organisation.update(organisation_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       flash[:success] = "Les informations de contact ont été modifiées"
       redirect_to admin_organisation_path(@organisation)
     else

--- a/app/controllers/admin/planning/agendas_controller.rb
+++ b/app/controllers/admin/planning/agendas_controller.rb
@@ -20,7 +20,9 @@ class Admin::Planning::AgendasController < AgentAuthController
 
   def toggle_displays
     authorize(current_agent, policy_class: Agent::AgentPolicy)
-    current_agent.update!(permitted_agent_params)
+    # `toggle_displays?` vérifie `record == current_agent`, ce qui reste vrai quels que soient les
+    # préférences d'affichage modifiées ici.
+    current_agent.update!(permitted_agent_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     redirect_back fallback_location: admin_organisation_planning_agenda_path(current_organisation)
   end
 

--- a/app/controllers/admin/territories/agent_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_roles_controller.rb
@@ -2,7 +2,11 @@ class Admin::Territories::AgentRolesController < Admin::Territories::BaseControl
   def update
     agent_role = AgentRole.find(params[:id])
     authorize(agent_role, policy_class: Agent::AgentRolePolicy)
-    if agent_role.update(agent_role_params)
+    # `agent_role_params` permet de changer `organisation_id`, mais `AgentRole#organisation_cannot_change`
+    # bloque déjà toute modification de ce champ sur un enregistrement existant (voir agent_role_spec.rb).
+    # `agent_id`/`access_level` ne sont pas utilisés par `territorial_admin_or_can_invite_agents?`, donc
+    # une ré-authorization après coup ne changerait pas le verdict : pas besoin de la faire ici.
+    if agent_role.update(agent_role_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       flash[:success] = "Les permissions de l'agent ont été mises à jour"
     else
       flash[:error] = agent_role.errors.full_messages.join(", ")

--- a/app/controllers/admin/territories/motif_categories_controller.rb
+++ b/app/controllers/admin/territories/motif_categories_controller.rb
@@ -1,7 +1,8 @@
 class Admin::Territories::MotifCategoriesController < Admin::Territories::BaseController
   def update
     authorize(current_territory, policy_class: Agent::TerritoryPolicy)
-    current_territory.update(motif_categories_params)
+    # `motif_category_ids` n'affecte pas `territorial_admin?` (basé sur le territoire lui-même).
+    current_territory.update(motif_categories_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     flash[:success] = "Configuration enregistrée"
     redirect_to edit_admin_territory_motif_fields_path(current_territory)
   end

--- a/app/controllers/admin/territories/motifs_controller.rb
+++ b/app/controllers/admin/territories/motifs_controller.rb
@@ -52,7 +52,9 @@ class Admin::Territories::MotifsController < Admin::Territories::BaseController
 
     Motif.transaction do
       @motifs.each do |motif|
-        motif.update(permitted_params)
+        # UPDATABLE_ATTRS (name/service_id/durée/couleur/instructions) n'affecte pas
+        # `agent_can_manage_motif?`, qui ne dépend que de `motif.organisation`.
+        motif.update(permitted_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       end
 
       raise ActiveRecord::Rollback unless @motifs.all?(&:valid?)

--- a/app/controllers/admin/territories/organisations_controller.rb
+++ b/app/controllers/admin/territories/organisations_controller.rb
@@ -43,7 +43,8 @@ class Admin::Territories::OrganisationsController < Admin::Territories::BaseCont
     end
 
     if organisation.reload.agents.empty?
-      organisation.update!(disabled_at: Time.zone.now)
+      # `disabled_at` n'affecte pas `territorial_admin?` (basé sur `record.territory`).
+      organisation.update!(disabled_at: Time.zone.now) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       flash[:success] = "L'organisation a été fermée."
     else
       flash[:error] = "L'organisation n'a pas pu être fermée parce que des agents on encore des rendez-vous à venir dans cette organisation."
@@ -62,7 +63,8 @@ class Admin::Territories::OrganisationsController < Admin::Territories::BaseCont
     authorize(@organisation, :reopen?, policy_class: Agent::OrganisationPolicy)
     @organisation.transaction do
       AgentRole.create!(organisation: @organisation, agent: current_agent, access_level: :admin)
-      @organisation.update!(disabled_at: nil)
+      # `disabled_at` n'affecte pas `territorial_admin?` (basé sur `record.territory`).
+      @organisation.update!(disabled_at: nil) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     end
     redirect_to admin_organisation_configuration_path(@organisation),
                 flash: { success: "Organisation rouverte ! Vous pouvez inviter des agents à la rejoindre." }

--- a/app/controllers/admin/territories/rdv_fields_controller.rb
+++ b/app/controllers/admin/territories/rdv_fields_controller.rb
@@ -5,7 +5,8 @@ class Admin::Territories::RdvFieldsController < Admin::Territories::BaseControll
 
   def update
     authorize(current_territory, policy_class: Agent::TerritoryPolicy)
-    current_territory.update(rdv_fields_params)
+    # Les toggles de champs RDV n'affectent pas `territorial_admin?` (basé sur le territoire lui-même).
+    current_territory.update(rdv_fields_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     flash[:success] = "Configuration enregistrée"
     redirect_to action: :edit
   end

--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -29,7 +29,8 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
 
   def update
     authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
-    current_territory.update!(services_params)
+    # `service_ids` n'affecte pas `manage_services?` (alias de `territorial_admin?`, basé sur le territoire).
+    current_territory.update!(services_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     flash[:success] = "Liste des services disponibles mise à jour"
 
     if params[:redirect_to_organisation_id].present?

--- a/app/controllers/admin/territories/user_fields_controller.rb
+++ b/app/controllers/admin/territories/user_fields_controller.rb
@@ -5,7 +5,8 @@ class Admin::Territories::UserFieldsController < Admin::Territories::BaseControl
 
   def update
     authorize(current_territory, policy_class: Agent::TerritoryPolicy)
-    current_territory.update!(user_fields_params)
+    # Les toggles de champs usager n'affectent pas `territorial_admin?` (basé sur le territoire lui-même).
+    current_territory.update!(user_fields_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
 
     flash[:success] = "Configuration enregistrée"
     redirect_to action: :edit

--- a/app/controllers/agents/outlook_sync_controller.rb
+++ b/app/controllers/agents/outlook_sync_controller.rb
@@ -8,7 +8,8 @@ class Agents::OutlookSyncController < AgentAuthController
 
   def destroy
     authorize(current_agent, :current_agent_or_admin_in_record_organisation?, policy_class: Agent::AgentPolicy)
-    current_agent.update!(outlook_disconnect_in_progress: true)
+    # `record` est `current_agent` lui-même : la policy reste vraie quel que soit l'attribut modifié.
+    current_agent.update!(outlook_disconnect_in_progress: true) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     Outlook::MassDestroyEventJob.perform_later(current_agent)
     flash[:success] = "Votre compte Outlook est bien en cours de déconnexion. " \
                       "Cette action peut prendre plusieurs minutes, nécessaires à la suppression de vos événements dans votre agenda. " \

--- a/app/controllers/agents/preferences_controller.rb
+++ b/app/controllers/agents/preferences_controller.rb
@@ -12,7 +12,8 @@ class Agents::PreferencesController < AgentAuthController
     @agent = current_agent
     authorize(@agent, policy_class: Agent::AgentPolicy)
 
-    if @agent.update(update_params)
+    # `record` est `current_agent` lui-même : la policy reste vraie quel que soit l'attribut modifié.
+    if @agent.update(update_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       redirect_to agents_preferences_path, flash: { success: t(".update.done") }
     else
       render :show

--- a/app/controllers/agents/webcal_sync_controller.rb
+++ b/app/controllers/agents/webcal_sync_controller.rb
@@ -9,7 +9,8 @@ class Agents::WebcalSyncController < AgentAuthController
 
   def update
     authorize(current_agent, policy_class: Agent::AgentPolicy)
-    current_agent.update!(calendar_uid: new_calendar_uid)
+    # `record` est `current_agent` lui-même : la policy reste vraie quel que soit l'attribut modifié.
+    current_agent.update!(calendar_uid: new_calendar_uid) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
     redirect_to agents_calendar_sync_webcal_sync_path, flash: { success: "Votre url de calendrier a été mise à jour." }
   end
 

--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -47,7 +47,9 @@ class Api::V1::AbsencesController < Api::V1::AgentAuthBaseController
   def update
     if @absence
       authorize(@absence, policy_class: Agent::AbsencePolicy)
-      @absence.update!(update_params)
+      # `update_params` (title/first_day/start_time/end_day/end_time) n'inclut pas `agent_id`,
+      # seul champ dont dépend `can_manage_absence?`.
+      @absence.update!(update_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       render_record @absence
     else
       render_error :not_found, not_found: :absence

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -54,7 +54,9 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     @rdv = Rdv.find(params[:rdv_id])
     authorize(@rdv, :update?, policy_class: Agent::RdvPolicy)
 
-    @rdv.update!(params.permit(:status))
+    # Seul `:status` est modifié, ce qui n'affecte pas `same_agent_or_has_access?` ni
+    # `users_and_agents_authorized?` (basés sur les usagers/agents/motif du RDV).
+    @rdv.update!(params.permit(:status)) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
 
     # Le blueprint complet du rendez-vous renvoie énormément d'information, qui ne sont pas pertinentes ici.
     # On va sans doute devoir restreindre la quantité de données renvoyées par ce blueprint pour rendre

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -11,7 +11,9 @@ class Users::UsersController < UserAuthController
     @user = current_user
     authorize(@user, policy_class: User::UserPolicy)
     @user_form = Users::EditForm.new(user: @user, domain: current_domain)
-    if @user.update(user_params)
+    # `record` est `current_user` lui-même (`record.id == current_user.id`), ce qui reste vrai
+    # quels que soient les attributs modifiés par `user_params`.
+    if @user.update(user_params) # rubocop:disable RdvServicePublic/PunditAuthorizeStaleAfterMutation
       update_ami_preferences
       flash[:success] = "Vos informations ont été mises à jour."
       redirect_to users_informations_path

--- a/lib/rubocop/cop/rdv_service_public/pundit_authorize_stale_after_mutation.rb
+++ b/lib/rubocop/cop/rdv_service_public/pundit_authorize_stale_after_mutation.rb
@@ -1,0 +1,97 @@
+module RuboCop
+  module Cop
+    module RdvServicePublic
+      # Détecte les cas où un objet est modifié (`update`, `update!`,
+      # `assign_attributes`) après avoir été passé à `authorize`, sans
+      # nouvel appel à `authorize` après la modification.
+      #
+      # Le problème : la policy Pundit est évaluée sur l'état de l'objet
+      # au moment de l'appel à `authorize`. Si des attributs pertinents
+      # pour la policy sont modifiés juste après, la vérification faite
+      # ne reflète plus l'état réellement sauvegardé.
+      #
+      # @example
+      #   # bad
+      #   authorize(@absence, policy_class: Agent::AbsencePolicy)
+      #   @absence.update!(update_params)
+      #
+      #   # good : les attributs sont fixés avant `authorize`, qui checke
+      #   # donc bien l'état final
+      #   @absence.assign_attributes(update_params)
+      #   authorize(@absence, policy_class: Agent::AbsencePolicy)
+      #   @absence.save!
+      #
+      #   # good : si l'attribution ne peut pas être faite avant (ex: on a besoin
+      #   # d'un authorize initial pour savoir quels champs sont permis), on
+      #   # peut re-checker après la modification
+      #   authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+      #   @territory.assign_attributes(params.require(:territory).permit(:category))
+      #   authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+      #   @territory.save
+      #
+      # Limite connue : ce cop ne regarde que dans la même méthode. Le cas où
+      # `authorize` est fait dans un `before_action` séparé et la mutation dans
+      # l'action elle-même n'est pas détecté (il faudrait suivre les `before_action`,
+      # ce qui produirait trop de faux positifs vu que c'est l'idiome standard du
+      # projet). Une revue humaine reste nécessaire pour ce cas.
+      class PunditAuthorizeStaleAfterMutation < Base
+        MUTATING_METHODS = %i[update update! assign_attributes].freeze
+
+        MSG = "`%<receiver>s` est modifié via `#%<method>s` après avoir été passé à `authorize`, " \
+              "sans nouvel `authorize` après la modification. Si les attributs modifiés peuvent " \
+              "changer le verdict de la policy, appelle `authorize` sur l'état final, juste avant `save`.".freeze
+
+        def on_def(node)
+          check_stale_authorizations(node)
+        end
+        alias on_defs on_def
+
+        private
+
+        def check_stale_authorizations(def_node)
+          events = collect_events(def_node)
+          return if events.empty?
+
+          events.group_by { |event| event[:receiver] }.each_value do |receiver_events|
+            authorize_positions = receiver_events.each_index.select { |i| receiver_events[i][:type] == :authorize }
+
+            receiver_events.each_with_index do |event, index|
+              next unless event[:type] == :mutation
+              next unless authorize_positions.any? { |i| i < index } # authorized at some point before
+              next if authorize_positions.any? { |i| i > index } # ...and re-authorized after: OK
+
+              add_offense(
+                event[:node].loc.selector,
+                message: format(MSG, receiver: event[:receiver], method: event[:node].method_name)
+              )
+            end
+          end
+        end
+
+        # Parcourt les appels dans l'ordre du texte source pour reconstituer
+        # la séquence "authorize / mutation" telle qu'elle sera exécutée.
+        def collect_events(def_node)
+          def_node.each_descendant(:send, :csend)
+            .sort_by { |node| node.source_range.begin_pos }
+            .filter_map { |node| build_event(node) }
+        end
+
+        def build_event(node)
+          if authorize_call?(node)
+            { type: :authorize, receiver: node.first_argument.source, node: node }
+          elsif mutation_call?(node)
+            { type: :mutation, receiver: node.receiver.source, node: node }
+          end
+        end
+
+        def authorize_call?(node)
+          node.method?(:authorize) && node.receiver.nil? && node.first_argument
+        end
+
+        def mutation_call?(node)
+          node.receiver && MUTATING_METHODS.include?(node.method_name) && node.arguments.any?
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/rubocop/cop/rdv_service_public/pundit_authorize_stale_after_mutation_spec.rb
+++ b/spec/lib/rubocop/cop/rdv_service_public/pundit_authorize_stale_after_mutation_spec.rb
@@ -1,0 +1,59 @@
+require "rubocop"
+require "rubocop/rspec/support"
+require Rails.root.join("lib/rubocop/cop/rdv_service_public/pundit_authorize_stale_after_mutation")
+
+RSpec.describe RuboCop::Cop::RdvServicePublic::PunditAuthorizeStaleAfterMutation do
+  include RuboCop::RSpec::ExpectOffense
+
+  subject(:cop) { described_class.new }
+
+  it "flags a mutation that happens after authorize, with no re-authorize after" do
+    expect_offense(<<~RUBY)
+      def update
+        authorize(@absence, policy_class: Agent::AbsencePolicy)
+        @absence.update!(update_params)
+                 ^^^^^^^ RdvServicePublic/PunditAuthorizeStaleAfterMutation: `@absence` est modifié via `#update!` après avoir été passé à `authorize`, sans nouvel `authorize` après la modification. Si les attributs modifiés peuvent changer le verdict de la policy, appelle `authorize` sur l'état final, juste avant `save`.
+      end
+    RUBY
+  end
+
+  it "does not flag when the record is re-authorized after the mutation" do
+    expect_no_offenses(<<~RUBY)
+      def update
+        authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+        @territory.assign_attributes(params.require(:territory).permit(:category))
+        authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+        @territory.save
+      end
+    RUBY
+  end
+
+  it "does not flag when attributes are assigned before authorize" do
+    expect_no_offenses(<<~RUBY)
+      def update
+        @user.assign_attributes(params_for_update)
+        authorize(@user, policy_class: Agent::UserPolicy)
+        @user.save!
+      end
+    RUBY
+  end
+
+  it "does not flag a mutation on an object that was never authorized" do
+    expect_no_offenses(<<~RUBY)
+      def update
+        authorize(@organisation, policy_class: Agent::OrganisationPolicy)
+        @other_record.update!(foo: 1)
+      end
+    RUBY
+  end
+
+  it "does not flag a bare save with no arguments after authorize" do
+    expect_no_offenses(<<~RUBY)
+      def create
+        motif = Motif.new(motif_params)
+        authorize(motif, policy_class: Agent::MotifPolicy)
+        motif.save!
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
WIP proposé par une LLM par Antoine

le cop détecte les cas comme 

```rb
authorize(resource)
resource.update!(unverified_id: 123)
```

et incite à faire

```rb
authorize(resource)
resource.assign_attributes(unverified_id: 123)
authorize(resource)
resource.save!
```

## Réflexions

Un souci de la syntaxe double `authorize` avant et après est que ça n'a pas vraiment de sens de demander à la policy 

```rb
current_user can :update? object_before_changes
current_user can :update? object_after_changes
```

Avec le même nom de policy `:update`, ça n'est pas suffisament souple. Par exemple peut-être que je veux autoriser la modification d'un motif pour passer de actif à archivé mais pas de archivé à actif (un peu tiré par les cheveux). 

### Piste FormObject / Changeset

- interdire toute policy `update?` sur un objet `ActiveRecord` 
- forcer à créer et authorize des `FormObject` ou des objets `Changeset` qui auraient a la fois le record avant `assign_attributes` et les attributs cibles ou le record post assign_attributes

La méthode d'autorisation de la policy pourrait (et devrait) alors verifier les permissions des deux

### Piste Dirty

- forcer a faire le `assign_attributes` sur le AR avant `authorize(:update?)`
- se baser sur les Dirty Methods de AR pour avoir les deux états avant-après assign_attributes et pouvoir faire toutes les validations nécessaires dans la policy method :update? 

a valider que dirty permet tout 
