### PR TITLE
Correction de l’affichage du dropdown de participation

### DIFF
--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -1,7 +1,7 @@
 module ParticipationsHelper
   def participation_status_dropdown_toggle(participation)
     tag.div(data: { toggle: "dropdown" },
-            class: "dropdown-toggle btn rdv-status-#{participation.temporal_status}") do
+            class: "dropdown-toggle rdv-status-toggle rdv-status-#{participation.temporal_status}") do
       Participation.human_attribute_value(:status, participation.temporal_status, disable_cast: true)
     end
   end


### PR DESCRIPTION
# Contexte

Suite à un retour au support, on s’est rendu compte que la couleur d’affichage du dropdown de participation n’était plus affichée.

# Solution

On remet la class CSS manquante

## Captures d'écran

Avant | Après
:- | -:
<img width="423" height="336" alt="image" src="https://github.com/user-attachments/assets/32d85346-ff79-43f3-85e3-ff73d3652ac8" /> | <img width="474" height="303" alt="image" src="https://github.com/user-attachments/assets/f4d128f9-393f-47a6-a723-1d4dbd45e715" />

